### PR TITLE
Remove -O3 flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
 endif()
 
 # Remove -O3 flag
-string(REPLACE "-O3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REPLACE "-O3" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
 if(MSVC)
     string(APPEND CMAKE_CXX_FLAGS " /WX")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,7 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 endif()
 
-# Remove -O3 flag
-string(REPLACE "-O3" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 
 if(MSVC)
     string(APPEND CMAKE_CXX_FLAGS " /WX")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 endif()
 
+# Remove -O3 flag
+string(REPLACE "-O3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
 if(MSVC)
     string(APPEND CMAKE_CXX_FLAGS " /WX")
 else()


### PR DESCRIPTION
In real product environment, the  -O3 flag could be lead to bug

From @sunhantao checking, -O3 still there in AWS server(ubuntu 18.04), But I cannot find the flag in my computer 