### PR TITLE
Improve uint256

### DIFF
--- a/src/crypto/uint256.h
+++ b/src/crypto/uint256.h
@@ -744,10 +744,10 @@ struct hash<uint256>
 {
     std::size_t operator()(const uint256& key) const
     {
-        std::size_t seed = 0;
-        std::string vBin(key.begin(), key.end());
-        seed = std::hash<std::string>()(vBin);
-        return seed;
+        std::size_t nSeed = 0;
+        std::string strKeyData(key.begin(), key.end());
+        nSeed = std::hash<std::string>()(strKeyData);
+        return nSeed;
     }
 };
 

--- a/src/crypto/uint256.h
+++ b/src/crypto/uint256.h
@@ -5,6 +5,7 @@
 #ifndef CRYPTO_UINT256_H
 #define CRYPTO_UINT256_H
 
+#include <boost/functional/hash.hpp>
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
@@ -733,6 +734,16 @@ public:
             memcpy(pn, &vch[0], sizeof(pn));
         else
             *this = 0;
+    }
+
+    std::size_t operator()(const uint256& key) const
+    {
+        std::size_t seed = 0;
+        for (int i = 0; i < key.size(); ++i)
+        {
+            boost::hash_combine(seed, key[i]);
+        }
+        return seed;
     }
 };
 

--- a/src/crypto/uint256.h
+++ b/src/crypto/uint256.h
@@ -27,7 +27,7 @@ protected:
     {
         WIDTH = BITS / 32
     };
-    unsigned int pn[WIDTH];
+    uint32 pn[WIDTH];
 
 public:
     bool operator!() const
@@ -57,8 +57,8 @@ public:
 
     base_uint& operator=(uint64 b)
     {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
+        pn[0] = (uint32)b;
+        pn[1] = (uint32)(b >> 32);
         for (int i = 2; i < WIDTH; i++)
             pn[i] = 0;
         return *this;
@@ -87,15 +87,15 @@ public:
 
     base_uint& operator^=(uint64 b)
     {
-        pn[0] ^= (unsigned int)b;
-        pn[1] ^= (unsigned int)(b >> 32);
+        pn[0] ^= (uint32)b;
+        pn[1] ^= (uint32)(b >> 32);
         return *this;
     }
 
     base_uint& operator|=(uint64 b)
     {
-        pn[0] |= (unsigned int)b;
-        pn[1] |= (unsigned int)(b >> 32);
+        pn[0] |= (uint32)b;
+        pn[1] |= (uint32)(b >> 32);
         return *this;
     }
 
@@ -201,12 +201,12 @@ public:
         return ret;
     }
 
-    unsigned int& operator[](size_t pos)
+    uint32& operator[](size_t pos)
     {
         return pn[pos];
     }
 
-    const unsigned int& operator[](size_t pos) const
+    const uint32& operator[](size_t pos) const
     {
         return pn[pos];
     }
@@ -269,9 +269,9 @@ public:
 
     friend inline bool operator==(const base_uint& a, uint64 b)
     {
-        if (a.pn[0] != (unsigned int)b)
+        if (a.pn[0] != (uint32)b)
             return false;
-        if (a.pn[1] != (unsigned int)(b >> 32))
+        if (a.pn[1] != (uint32)(b >> 32))
             return false;
         for (int i = 2; i < base_uint::WIDTH; i++)
             if (a.pn[i] != 0)
@@ -364,7 +364,7 @@ public:
         return (unsigned char*)&pn[WIDTH];
     }
 
-    static unsigned int size()
+    static uint32 size()
     {
         return sizeof(pn);
     }
@@ -449,16 +449,16 @@ public:
 
     uint160(uint64 b)
     {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
+        pn[0] = (uint32)b;
+        pn[1] = (uint32)(b >> 32);
         for (int i = 2; i < WIDTH; i++)
             pn[i] = 0;
     }
 
     uint160& operator=(uint64 b)
     {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
+        pn[0] = (uint32)b;
+        pn[1] = (uint32)(b >> 32);
         for (int i = 2; i < WIDTH; i++)
             pn[i] = 0;
         return *this;
@@ -698,8 +698,8 @@ public:
 
     uint256(const uint64 b)
     {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
+        pn[0] = (uint32)b;
+        pn[1] = (uint32)(b >> 32);
         for (int i = 2; i < WIDTH; i++)
             pn[i] = 0;
     }
@@ -708,15 +708,15 @@ public:
     {
         for (int i = 0; i < 4; i++)
         {
-            pn[2 * i] = (unsigned int)b[i];
-            pn[2 * i + 1] = (unsigned int)(b[i] >> 32);
+            pn[2 * i] = (uint32)b[i];
+            pn[2 * i + 1] = (uint32)(b[i] >> 32);
         }
     }
 
     uint256& operator=(uint64 b)
     {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
+        pn[0] = (uint32)b;
+        pn[1] = (uint32)(b >> 32);
         for (int i = 2; i < WIDTH; i++)
             pn[i] = 0;
         return *this;
@@ -955,16 +955,16 @@ public:
 
     uint224(const uint64 b)
     {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
+        pn[0] = (uint32)b;
+        pn[1] = (uint32)(b >> 32);
         for (int i = 2; i < WIDTH; i++)
             pn[i] = 0;
     }
 
     uint224& operator=(uint64 b)
     {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
+        pn[0] = (uint32)b;
+        pn[1] = (uint32)(b >> 32);
         for (int i = 2; i < WIDTH; i++)
             pn[i] = 0;
         return *this;

--- a/src/crypto/uint256.h
+++ b/src/crypto/uint256.h
@@ -5,7 +5,6 @@
 #ifndef CRYPTO_UINT256_H
 #define CRYPTO_UINT256_H
 
-#include <boost/functional/hash.hpp>
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
@@ -735,17 +734,24 @@ public:
         else
             *this = 0;
     }
+};
 
+namespace std
+{
+
+template <>
+struct hash<uint256>
+{
     std::size_t operator()(const uint256& key) const
     {
         std::size_t seed = 0;
-        for (int i = 0; i < key.size(); ++i)
-        {
-            boost::hash_combine(seed, key[i]);
-        }
+        std::string vBin(key.begin(), key.end());
+        seed = std::hash<std::string>()(vBin);
         return seed;
     }
 };
+
+} // namespace std
 
 inline bool operator==(const uint256& a, uint64 b)
 {

--- a/test/uint256_tests.cpp
+++ b/test/uint256_tests.cpp
@@ -5,6 +5,7 @@
 #include "uint256.h"
 
 #include <boost/test/unit_test.hpp>
+#include <unordered_map>
 
 #include "test_big.h"
 //#include <stdint.h>
@@ -245,6 +246,34 @@ BOOST_AUTO_TEST_CASE(methods) // GetHex SetHex begin() end() size() GetLow64 Get
     ss >> TmpS;
     BOOST_CHECK(MaxS == TmpS);
     ss.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(uint256_hash)
+{
+    std::unordered_map<uint256, std::string> test_map;
+    test_map[R1L] = "R1L";
+    test_map[R2L] = "R2L";
+
+    BOOST_CHECK(test_map.size() == 2);
+    BOOST_CHECK(test_map[R1L] == "R1L");
+    BOOST_CHECK(test_map[R2L] == "R2L");
+
+    uint256 r1l_copy = R1L;
+    BOOST_CHECK(r1l_copy == R1L);
+    BOOST_CHECK(test_map[r1l_copy] == "R1L");
+
+    std::unordered_map<std::string, std::string> test_str_map;
+    std::string strR1L = "R1L";
+    std::string strR2L = "R2L";
+    test_str_map[strR1L] = "R1L_VALUE";
+    test_str_map[strR2L] = "R2L_VALUE";
+
+    BOOST_CHECK(test_str_map.size() == 2);
+    BOOST_CHECK(test_str_map[strR1L] == "R1L_VALUE");
+    BOOST_CHECK(test_str_map[strR1L] == "R1L_VALUE");
+
+    std::string r1l_str_copy = strR1L;
+    BOOST_CHECK(test_str_map[r1l_str_copy] == "R1L_VALUE");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Replace unsigned int to uint32 for the type of base_uint::pn
- Implemented hash func for uint256, prepared for using unordered_map<uint256,xxxx> 

References:
- https://en.cppreference.com/w/cpp/utility/hash
- https://www.boost.org/doc/libs/1_55_0/doc/html/hash/combine.html
- https://stackoverflow.com/questions/17016175/c-unordered-map-using-a-custom-class-type-as-the-key
- https://github.com/bitly/dablooms/pull/19
- https://llimllib.github.io/bloomfilter-tutorial/