### PR TITLE
Actor worker

### DIFF
--- a/src/bigbang/delegatedchn.cpp
+++ b/src/bigbang/delegatedchn.cpp
@@ -255,12 +255,12 @@ bool CDelegatedChannel::HandleInitialize()
         return false;
     }
 
-    RegisterHandler<CPeerActiveMessage>(boost::bind(&CDelegatedChannel::HandleActive, this, _1));
-    RegisterHandler<CPeerDeactiveMessage>(boost::bind(&CDelegatedChannel::HandleDeactive, this, _1));
-    RegisterHandler<CPeerBulletinMessageInBound>(boost::bind(&CDelegatedChannel::HandleBulletin, this, _1));
-    RegisterHandler<CPeerGetDelegatedMessageInBound>(boost::bind(&CDelegatedChannel::HandleGetDelegate, this, _1));
-    RegisterHandler<CPeerDistributeMessageInBound>(boost::bind(&CDelegatedChannel::HandleDistribute, this, _1));
-    RegisterHandler<CPeerPublishMessageInBound>(boost::bind(&CDelegatedChannel::HandlePublish, this, _1));
+    RegisterRefHandler<CPeerActiveMessage>(boost::bind(&CDelegatedChannel::HandleActive, this, _1));
+    RegisterRefHandler<CPeerDeactiveMessage>(boost::bind(&CDelegatedChannel::HandleDeactive, this, _1));
+    RegisterRefHandler<CPeerBulletinMessageInBound>(boost::bind(&CDelegatedChannel::HandleBulletin, this, _1));
+    RegisterRefHandler<CPeerGetDelegatedMessageInBound>(boost::bind(&CDelegatedChannel::HandleGetDelegate, this, _1));
+    RegisterRefHandler<CPeerDistributeMessageInBound>(boost::bind(&CDelegatedChannel::HandleDistribute, this, _1));
+    RegisterRefHandler<CPeerPublishMessageInBound>(boost::bind(&CDelegatedChannel::HandlePublish, this, _1));
 
     return true;
 }

--- a/src/bigbang/netchn.cpp
+++ b/src/bigbang/netchn.cpp
@@ -151,15 +151,15 @@ bool CNetChannel::HandleInitialize()
         return false;
     }
 
-    RegisterHandler<CPeerActiveMessage>(boost::bind(&CNetChannel::HandleActive, this, _1));
-    RegisterHandler<CPeerDeactiveMessage>(boost::bind(&CNetChannel::HandleDeactive, this, _1));
-    RegisterHandler<CPeerSubscribeMessageInBound>(boost::bind(&CNetChannel::HandleSubscribe, this, _1));
-    RegisterHandler<CPeerUnsubscribeMessageInBound>(boost::bind(&CNetChannel::HandleUnsubscribe, this, _1));
-    RegisterHandler<CPeerInvMessageInBound>(boost::bind(&CNetChannel::HandleInv, this, _1));
-    RegisterHandler<CPeerGetDataMessageInBound>(boost::bind(&CNetChannel::HandleGetData, this, _1));
-    RegisterHandler<CPeerGetBlocksMessageInBound>(boost::bind(&CNetChannel::HandleGetBlocks, this, _1));
-    RegisterHandler<CPeerTxMessageInBound>(boost::bind(&CNetChannel::HandlePeerTx, this, _1));
-    RegisterHandler<CPeerBlockMessageInBound>(boost::bind(&CNetChannel::HandlePeerBlock, this, _1));
+    RegisterRefHandler<CPeerActiveMessage>(boost::bind(&CNetChannel::HandleActive, this, _1));
+    RegisterRefHandler<CPeerDeactiveMessage>(boost::bind(&CNetChannel::HandleDeactive, this, _1));
+    RegisterRefHandler<CPeerSubscribeMessageInBound>(boost::bind(&CNetChannel::HandleSubscribe, this, _1));
+    RegisterRefHandler<CPeerUnsubscribeMessageInBound>(boost::bind(&CNetChannel::HandleUnsubscribe, this, _1));
+    RegisterRefHandler<CPeerInvMessageInBound>(boost::bind(&CNetChannel::HandleInv, this, _1));
+    RegisterRefHandler<CPeerGetDataMessageInBound>(boost::bind(&CNetChannel::HandleGetData, this, _1));
+    RegisterRefHandler<CPeerGetBlocksMessageInBound>(boost::bind(&CNetChannel::HandleGetBlocks, this, _1));
+    RegisterRefHandler<CPeerTxMessageInBound>(boost::bind(&CNetChannel::HandlePeerTx, this, _1));
+    RegisterRefHandler<CPeerBlockMessageInBound>(boost::bind(&CNetChannel::HandlePeerBlock, this, _1));
 
     return true;
 }

--- a/src/bigbang/txpool.cpp
+++ b/src/bigbang/txpool.cpp
@@ -141,10 +141,10 @@ bool CTxPool::HandleInitialize()
         return false;
     }
 
-    RegisterHandler<CAddTxMessage>(boost::bind(&CTxPool::HandleAddTx, this, _1));
-    RegisterHandler<CRemoveTxMessage>(boost::bind(&CTxPool::HandleRemoveTx, this, _1));
-    RegisterHandler<CClearTxMessage>(boost::bind(&CTxPool::HandleClearTx, this, _1));
-    RegisterHandler<CAddedBlockMessage>(boost::bind(&CTxPool::HandleAddedBlock, this, _1));
+    RegisterRefHandler<CAddTxMessage>(boost::bind(&CTxPool::HandleAddTx, this, _1));
+    RegisterRefHandler<CRemoveTxMessage>(boost::bind(&CTxPool::HandleRemoveTx, this, _1));
+    RegisterRefHandler<CClearTxMessage>(boost::bind(&CTxPool::HandleClearTx, this, _1));
+    RegisterRefHandler<CAddedBlockMessage>(boost::bind(&CTxPool::HandleAddedBlock, this, _1));
 
     return true;
 }

--- a/src/network/peernet.cpp
+++ b/src/network/peernet.cpp
@@ -53,18 +53,18 @@ bool CBbPeerNet::HandleInitialize()
         return false;
     }
 
-    RegisterHandler<CPeerSubscribeMessageOutBound>(boost::bind(&CBbPeerNet::HandleSubscribe, this, _1));
-    RegisterHandler<CPeerUnsubscribeMessageOutBound>(boost::bind(&CBbPeerNet::HandleUnsubscribe, this, _1));
-    RegisterHandler<CPeerInvMessageOutBound>(boost::bind(&CBbPeerNet::HandleInv, this, _1));
-    RegisterHandler<CPeerGetDataMessageOutBound>(boost::bind(&CBbPeerNet::HandleGetData, this, _1));
-    RegisterHandler<CPeerGetBlocksMessageOutBound>(boost::bind(&CBbPeerNet::HandleGetBlocks, this, _1));
-    RegisterHandler<CPeerTxMessageOutBound>(boost::bind(&CBbPeerNet::HandlePeerTx, this, _1));
-    RegisterHandler<CPeerBlockMessageOutBound>(boost::bind(&CBbPeerNet::HandlePeerBlock, this, _1));
+    RegisterRefHandler<CPeerSubscribeMessageOutBound>(boost::bind(&CBbPeerNet::HandleSubscribe, this, _1));
+    RegisterRefHandler<CPeerUnsubscribeMessageOutBound>(boost::bind(&CBbPeerNet::HandleUnsubscribe, this, _1));
+    RegisterRefHandler<CPeerInvMessageOutBound>(boost::bind(&CBbPeerNet::HandleInv, this, _1));
+    RegisterRefHandler<CPeerGetDataMessageOutBound>(boost::bind(&CBbPeerNet::HandleGetData, this, _1));
+    RegisterRefHandler<CPeerGetBlocksMessageOutBound>(boost::bind(&CBbPeerNet::HandleGetBlocks, this, _1));
+    RegisterRefHandler<CPeerTxMessageOutBound>(boost::bind(&CBbPeerNet::HandlePeerTx, this, _1));
+    RegisterRefHandler<CPeerBlockMessageOutBound>(boost::bind(&CBbPeerNet::HandlePeerBlock, this, _1));
 
-    RegisterHandler<CPeerBulletinMessageOutBound>(boost::bind(&CBbPeerNet::HandleBulletin, this, _1));
-    RegisterHandler<CPeerGetDelegatedMessageOutBound>(boost::bind(&CBbPeerNet::HandleGetDelegate, this, _1));
-    RegisterHandler<CPeerDistributeMessageOutBound>(boost::bind(&CBbPeerNet::HandleDistribute, this, _1));
-    RegisterHandler<CPeerPublishMessageOutBound>(boost::bind(&CBbPeerNet::HandlePublish, this, _1));
+    RegisterRefHandler<CPeerBulletinMessageOutBound>(boost::bind(&CBbPeerNet::HandleBulletin, this, _1));
+    RegisterRefHandler<CPeerGetDelegatedMessageOutBound>(boost::bind(&CBbPeerNet::HandleGetDelegate, this, _1));
+    RegisterRefHandler<CPeerDistributeMessageOutBound>(boost::bind(&CBbPeerNet::HandleDistribute, this, _1));
+    RegisterRefHandler<CPeerPublishMessageOutBound>(boost::bind(&CBbPeerNet::HandlePublish, this, _1));
 
     return true;
 }

--- a/src/xengine/CMakeLists.txt
+++ b/src/xengine/CMakeLists.txt
@@ -42,6 +42,7 @@ set(sources
     lockfree/queue.h
     message/message.h
     message/actor.h         message/actor.cpp
+    message/actorworker.h   message/actorworker.cpp
     message/messagecenter.h message/messagecenter.cpp
     peernet/message.h
     db/kvdb.h

--- a/src/xengine/base/base.cpp
+++ b/src/xengine/base/base.cpp
@@ -22,24 +22,24 @@ IBase::IBase()
     status = STATUS_OUTDOCKER;
 }
 
-IBase::IBase(const string& ownKeyIn)
+IBase::IBase(const string& strOwnKeyIn)
 {
     status = STATUS_OUTDOCKER;
-    ownKey = ownKeyIn;
+    strOwnKey = strOwnKeyIn;
 }
 
 IBase::~IBase()
 {
 }
 
-void IBase::SetOwnKey(const string& ownKeyIn)
+void IBase::SetOwnKey(const string& strOwnKeyIn)
 {
-    ownKey = ownKeyIn;
+    strOwnKey = strOwnKeyIn;
 }
 
 string& IBase::GetOwnKey()
 {
-    return ownKey;
+    return strOwnKey;
 }
 
 Status IBase::GetStatus()
@@ -125,7 +125,7 @@ void IBase::HandleHalt()
 void IBase::FatalError()
 {
     Log("Fatal Error!!!!!\n");
-    pDocker->FatalError(ownKey.c_str());
+    pDocker->FatalError(strOwnKey.c_str());
 }
 
 void IBase::Log(const char* pszFormat, ...)
@@ -134,7 +134,7 @@ void IBase::Log(const char* pszFormat, ...)
     {
         va_list ap;
         va_start(ap, pszFormat);
-        pDocker->LogOutput(ownKey.c_str(), "[INFO]", pszFormat, ap);
+        pDocker->LogOutput(strOwnKey.c_str(), "[INFO]", pszFormat, ap);
         va_end(ap);
     }
 }
@@ -145,7 +145,7 @@ void IBase::Debug(const char* pszFormat, ...)
     {
         va_list ap;
         va_start(ap, pszFormat);
-        pDocker->LogOutput(ownKey.c_str(), "[DEBUG]", pszFormat, ap);
+        pDocker->LogOutput(strOwnKey.c_str(), "[DEBUG]", pszFormat, ap);
         va_end(ap);
     }
 }
@@ -154,7 +154,7 @@ void IBase::VDebug(const char* pszFormat, va_list ap)
 {
     if (pDocker != nullptr && pDocker->GetConfig()->fDebug)
     {
-        pDocker->LogOutput(ownKey.c_str(), "[DEBUG]", pszFormat, ap);
+        pDocker->LogOutput(strOwnKey.c_str(), "[DEBUG]", pszFormat, ap);
     }
 }
 
@@ -164,7 +164,7 @@ void IBase::Warn(const char* pszFormat, ...)
     {
         va_list ap;
         va_start(ap, pszFormat);
-        pDocker->LogOutput(ownKey.c_str(), "[WARN]", pszFormat, ap);
+        pDocker->LogOutput(strOwnKey.c_str(), "[WARN]", pszFormat, ap);
         va_end(ap);
     }
 }
@@ -175,7 +175,7 @@ void IBase::Error(const char* pszFormat, ...)
     {
         va_list ap;
         va_start(ap, pszFormat);
-        pDocker->LogOutput(ownKey.c_str(), "[ERROR]", pszFormat, ap);
+        pDocker->LogOutput(strOwnKey.c_str(), "[ERROR]", pszFormat, ap);
         va_end(ap);
     }
 }
@@ -210,7 +210,7 @@ uint32 IBase::SetTimer(int64 nMilliSeconds, TimerCallback fnCallback)
 {
     if (pDocker != nullptr)
     {
-        return pDocker->SetTimer(ownKey, nMilliSeconds, fnCallback);
+        return pDocker->SetTimer(strOwnKey, nMilliSeconds, fnCallback);
     }
     return 0;
 }

--- a/src/xengine/base/base.h
+++ b/src/xengine/base/base.h
@@ -27,9 +27,9 @@ class IBase : virtual public CEventListener
 {
 public:
     IBase();
-    IBase(const std::string& ownKeyIn);
+    IBase(const std::string& strOwnKeyIn);
     virtual ~IBase();
-    void SetOwnKey(const std::string& ownKeyIn);
+    void SetOwnKey(const std::string& strOwnKeyIn);
     std::string& GetOwnKey();
     Status GetStatus();
     void Connect(CDocker* pDockerIn);
@@ -65,7 +65,7 @@ protected:
     const std::string GetWarnings();
 
 private:
-    std::string ownKey;
+    std::string strOwnKey;
     CDocker* pDocker;
     Status status;
 };

--- a/src/xengine/base/controller.h
+++ b/src/xengine/base/controller.h
@@ -15,8 +15,8 @@ namespace xengine
 class IController : public IBase
 {
 public:
-    IController(const std::string& ownKeyIn = "")
-      : IBase(ownKeyIn) {}
+    IController(const std::string& strOwnKeyIn = "")
+      : IBase(strOwnKeyIn) {}
 };
 
 } // namespace xengine

--- a/src/xengine/base/model.h
+++ b/src/xengine/base/model.h
@@ -15,8 +15,8 @@ namespace xengine
 class IModel : public IBase
 {
 public:
-    IModel(const std::string& ownKeyIn = "")
-      : IBase(ownKeyIn) {}
+    IModel(const std::string& strOwnKeyIn = "")
+      : IBase(strOwnKeyIn) {}
 };
 
 } // namespace xengine

--- a/src/xengine/console/console.cpp
+++ b/src/xengine/console/console.cpp
@@ -25,9 +25,9 @@ namespace xengine
 CConsole* CConsole::pCurrentConsole = nullptr;
 boost::mutex CConsole::mutexConsole;
 
-CConsole::CConsole(const string& ownKeyIn, const string& strPromptIn)
-  : IBase(ownKeyIn),
-    thrConsole(ownKeyIn, boost::bind(&CConsole::ConsoleThreadFunc, this)), strPrompt(strPromptIn),
+CConsole::CConsole(const string& strOwnKeyIn, const string& strPromptIn)
+  : IBase(strOwnKeyIn),
+    thrConsole(strOwnKeyIn, boost::bind(&CConsole::ConsoleThreadFunc, this)), strPrompt(strPromptIn),
     ioStrand(ioService),
 #ifdef WIN32
     inStream(ioService, GetStdHandle(STD_INPUT_HANDLE))

--- a/src/xengine/console/console.h
+++ b/src/xengine/console/console.h
@@ -23,7 +23,7 @@ namespace xengine
 class CConsole : public IBase
 {
 public:
-    CConsole(const std::string& ownKeyIn, const std::string& strPromptIn);
+    CConsole(const std::string& strOwnKeyIn, const std::string& strPromptIn);
     virtual ~CConsole();
     bool DispatchEvent(CEvent* pEvent) override;
     void DispatchLine(const std::string& strLine);

--- a/src/xengine/docker/timer.cpp
+++ b/src/xengine/docker/timer.cpp
@@ -27,8 +27,8 @@ CTimer::~CTimer()
 
 bool CTimer::HandleInitialize()
 {
-    RegisterHandler<CSetTimerMessage>(boost::bind(&CTimer::SetTimer, this, _1));
-    RegisterHandler<CCancelTimerMessage>(boost::bind(&CTimer::CancelTimer, this, _1));
+    RegisterRefHandler<CSetTimerMessage>(boost::bind(&CTimer::SetTimer, this, _1));
+    RegisterRefHandler<CCancelTimerMessage>(boost::bind(&CTimer::CancelTimer, this, _1));
     return true;
 }
 

--- a/src/xengine/event/eventproc.cpp
+++ b/src/xengine/event/eventproc.cpp
@@ -14,9 +14,9 @@ namespace xengine
 ///////////////////////////////
 // CEventProc
 
-CEventProc::CEventProc(const string& ownKeyIn)
-  : IBase(ownKeyIn),
-    thrEventQue(ownKeyIn + "-eventq", boost::bind(&CEventProc::EventThreadFunc, this))
+CEventProc::CEventProc(const string& strOwnKeyIn)
+  : IBase(strOwnKeyIn),
+    thrEventQue(strOwnKeyIn + "-eventq", boost::bind(&CEventProc::EventThreadFunc, this))
 {
 }
 

--- a/src/xengine/event/eventproc.h
+++ b/src/xengine/event/eventproc.h
@@ -81,7 +81,7 @@ protected:
 class CEventProc : public IBase
 {
 public:
-    CEventProc(const std::string& ownKeyIn);
+    CEventProc(const std::string& strOwnKeyIn);
     void PostEvent(CEvent* pEvent);
 
 protected:

--- a/src/xengine/lockfree/queue.h
+++ b/src/xengine/lockfree/queue.h
@@ -21,7 +21,7 @@ public:
 };
 
 template <typename T>
-class ListMPSCQueue : public LockFreeQueue<T, std::shared_ptr<T>>
+class ListMPSCQueue : public LockFreeQueue<T, const std::shared_ptr<T>>
 {
 public:
     typedef T* Ptr;
@@ -31,10 +31,10 @@ public:
     {
         CNode(Ptr t)
           : t(t), pNext(nullptr) {}
-        CNode(SPtr t)
+        CNode(const SPtr t)
           : t(t), pNext(nullptr) {}
 
-        SPtr t;
+        const SPtr t;
         std::atomic<CNode*> pNext;
     };
 
@@ -49,19 +49,19 @@ public:
         Clear();
     }
 
-    void Push(Ptr t)
+    void Push(const Ptr t)
     {
         Push(SPtr(t));
     }
 
-    void Push(SPtr t)
+    void Push(const SPtr t)
     {
         CNode* pNode = new CNode(t);
         CNode* pPrev = pTail.exchange(pNode, std::memory_order_release);
         pPrev->pNext.store(pNode, std::memory_order_relaxed);
     }
 
-    SPtr Pop()
+    const SPtr Pop()
     {
         CNode* pNode = pHead->pNext.load(std::memory_order_relaxed);
         if (pNode)

--- a/src/xengine/message/actorworker.cpp
+++ b/src/xengine/message/actorworker.cpp
@@ -21,7 +21,7 @@ CIOActorWorker::~CIOActorWorker()
     mapHandler.clear();
 }
 
-void CIOActorWorker::Publish(const std::shared_ptr<CMessage> spMessage)
+void CIOActorWorker::Publish(std::shared_ptr<CMessage> spMessage)
 {
     ioStrand.post(boost::bind(&CIOActorWorker::MessageHandler, this, spMessage));
 }
@@ -89,7 +89,7 @@ void CIOActorWorker::HandlerThreadFunc()
     LeaveLoop();
 }
 
-void CIOActorWorker::MessageHandler(const std::shared_ptr<CMessage> spMessage)
+void CIOActorWorker::MessageHandler(std::shared_ptr<CMessage> spMessage)
 {
     auto it = mapHandler.find(spMessage->Type());
     if (it != mapHandler.end())

--- a/src/xengine/message/actorworker.cpp
+++ b/src/xengine/message/actorworker.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2019 The Bigbang developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "actorworker.h"
+
+#include "logger.h"
+#include "message/message.h"
+
+namespace xengine
+{
+
+CIOActorWorker::CIOActorWorker(const std::string& strNameIn)
+  : thrIOActorWorker(strNameIn, boost::bind(&CIOActorWorker::HandlerThreadFunc, this)),
+    ioStrand(ioService), ioWork(ioService)
+{
+}
+
+CIOActorWorker::~CIOActorWorker()
+{
+    mapHandler.clear();
+}
+
+void CIOActorWorker::Publish(const std::shared_ptr<CMessage> spMessage)
+{
+    ioStrand.post(boost::bind(&CIOActorWorker::MessageHandler, this, spMessage));
+}
+
+void CIOActorWorker::EnterLoop()
+{
+}
+
+void CIOActorWorker::LeaveLoop()
+{
+}
+
+void CIOActorWorker::DeregisterHandler(const uint32 nType)
+{
+    mapHandler.erase(nType);
+}
+
+void CIOActorWorker::Stop()
+{
+    if (!ioService.stopped())
+    {
+        ioService.stop();
+    }
+
+    thrIOActorWorker.Interrupt();
+    thrIOActorWorker.Exit();
+}
+
+boost::asio::io_service& CIOActorWorker::GetService()
+{
+    return ioService;
+}
+
+boost::asio::io_service::strand& CIOActorWorker::GetStrand()
+{
+    return ioStrand;
+}
+
+CThread& CIOActorWorker::GetThread()
+{
+    return thrIOActorWorker;
+}
+
+void CIOActorWorker::HandlerThreadFunc()
+{
+    ioService.reset();
+
+    EnterLoop();
+
+    try
+    {
+        ioService.run();
+    }
+    catch (const boost::system::system_error& err)
+    {
+        // TODO: Replace newer api
+        ErrorLog("", "Failed to run CIOActorWorker io_service: %s\n", err.what());
+    }
+    catch (...)
+    {
+        // TODO: Replace newer api
+        ErrorLog("", "Failed to run CIOActorWorker io_service: unknown error\n");
+    }
+
+    LeaveLoop();
+}
+
+void CIOActorWorker::MessageHandler(const std::shared_ptr<CMessage> spMessage)
+{
+    auto it = mapHandler.find(spMessage->Type());
+    if (it != mapHandler.end())
+    {
+        spMessage->Handle(it->second);
+    }
+}
+
+} // namespace xengine

--- a/src/xengine/message/actorworker.h
+++ b/src/xengine/message/actorworker.h
@@ -45,7 +45,7 @@ public:
      * @param spMessage a shared_ptr object of CMessage or it's derived
      * @note Thread safe.
      */
-    void Publish(const std::shared_ptr<CMessage> spMessage);
+    void Publish(std::shared_ptr<CMessage> spMessage);
 
     /**
      * @brief Stop service.
@@ -132,7 +132,7 @@ private:
     /// The function of the thread entry contains ioService.run().
     void HandlerThreadFunc();
     /// Message handler callback entry.
-    void MessageHandler(const std::shared_ptr<CMessage> spMessage);
+    void MessageHandler(std::shared_ptr<CMessage> spMessage);
 
 protected:
     boost::asio::io_service ioService;

--- a/src/xengine/message/message.h
+++ b/src/xengine/message/message.h
@@ -28,7 +28,7 @@ namespace xengine
  *     };
  * @endcode
  */
-class CMessage
+class CMessage : public std::enable_shared_from_this<CMessage>
 {
 public:
     /**
@@ -64,39 +64,54 @@ protected:
         static uint32 nType = 0;
         return ++nType;
     }
+
+    template <typename Derived>
+    std::shared_ptr<Derived> SharedFromBase()
+    {
+        return std::static_pointer_cast<Derived>(shared_from_this());
+    }
 };
 
 /**
  * @brief Create the virtual function of class derived from CMessage: Type() and destructor.
  * @param cls Derived class name.
  */
-#define GENERATE_MESSAGE_FUNCTION(cls)                                          \
-    template <typename... Args>                                                 \
-    static std::shared_ptr<cls> Create(Args&&... args)                          \
-    {                                                                           \
-        return std::make_shared<cls>(std::forward<Args>(args)...);              \
-    }                                                                           \
-    static uint32 MessageType()                                                 \
-    {                                                                           \
-        static const uint32 nType = CMessage::NewMessageType();                 \
-        return nType;                                                           \
-    }                                                                           \
-    static std::string MessageTag()                                             \
-    {                                                                           \
-        static const std::string strTag = #cls;                                 \
-        return strTag;                                                          \
-    }                                                                           \
-    virtual uint32 Type() const override                                        \
-    {                                                                           \
-        return cls::MessageType();                                              \
-    }                                                                           \
-    virtual std::string Tag() const override                                    \
-    {                                                                           \
-        return cls::MessageTag();                                               \
-    }                                                                           \
-    virtual void Handle(boost::any handler) override                            \
-    {                                                                           \
-        boost::any_cast<boost::function<void(const cls& msg)>>(handler)(*this); \
+#define GENERATE_MESSAGE_FUNCTION(cls)                                                            \
+    template <typename... Args>                                                                   \
+    static std::shared_ptr<cls> Create(Args&&... args)                                            \
+    {                                                                                             \
+        return std::make_shared<cls>(std::forward<Args>(args)...);                                \
+    }                                                                                             \
+    static uint32 MessageType()                                                                   \
+    {                                                                                             \
+        static const uint32 nType = CMessage::NewMessageType();                                   \
+        return nType;                                                                             \
+    }                                                                                             \
+    static std::string MessageTag()                                                               \
+    {                                                                                             \
+        static const std::string strTag = #cls;                                                   \
+        return strTag;                                                                            \
+    }                                                                                             \
+    virtual uint32 Type() const override                                                          \
+    {                                                                                             \
+        return cls::MessageType();                                                                \
+    }                                                                                             \
+    virtual std::string Tag() const override                                                      \
+    {                                                                                             \
+        return cls::MessageTag();                                                                 \
+    }                                                                                             \
+    virtual void Handle(boost::any handler) override                                              \
+    {                                                                                             \
+        try                                                                                       \
+        {                                                                                         \
+            auto f = boost::any_cast<boost::function<void(const std::shared_ptr<cls>)>>(handler); \
+            f(SharedFromBase<cls>());                                                             \
+        }                                                                                         \
+        catch (const boost::bad_any_cast&)                                                          \
+        {                                                                                         \
+            auto f = boost::any_cast<boost::function<void(const cls&)>>(handler);                 \
+            f(*this);                                                                             \
+        }                                                                                         \
     }
 
 } // namespace xengine

--- a/src/xengine/netio/ioproc.cpp
+++ b/src/xengine/netio/ioproc.cpp
@@ -71,8 +71,8 @@ void CIOCompletion::Reset()
 ///////////////////////////////
 // CIOProc
 
-CIOProc::CIOProc(const string& ownKeyIn)
-  : CIOActor(ownKeyIn),
+CIOProc::CIOProc(const string& strOwnKeyIn)
+  : CIOActor(strOwnKeyIn),
     resolverHost(ioService), ioOutBound(this), ioSSLOutBound(this),
     timerHeartbeat(ioService, IOPROC_HEARTBEAT)
 {

--- a/src/xengine/netio/ioproc.h
+++ b/src/xengine/netio/ioproc.h
@@ -55,7 +55,7 @@ class CIOProc : public CIOActor
     friend class CIOInBound;
 
 public:
-    CIOProc(const std::string& ownKeyIn = "");
+    CIOProc(const std::string& strOwnKeyIn = "");
     virtual ~CIOProc();
     boost::asio::io_service& GetIoService();
     boost::asio::io_service::strand& GetIoStrand();

--- a/src/xengine/netio/netio.h
+++ b/src/xengine/netio/netio.h
@@ -12,16 +12,16 @@ namespace xengine
 class IIOProc : public IBase
 {
 public:
-    IIOProc(const std::string& ownKeyIn)
-      : IBase(ownKeyIn) {}
+    IIOProc(const std::string& strOwnKeyIn)
+      : IBase(strOwnKeyIn) {}
     virtual bool DispatchEvent(CEvent* pEvent) = 0;
 };
 
 class IIOModule : public CEventProc
 {
 public:
-    IIOModule(const std::string& ownKeyIn)
-      : CEventProc(ownKeyIn) {}
+    IIOModule(const std::string& strOwnKeyIn)
+      : CEventProc(strOwnKeyIn) {}
 };
 
 } // namespace xengine

--- a/src/xengine/peernet/peernet.cpp
+++ b/src/xengine/peernet/peernet.cpp
@@ -22,11 +22,11 @@ namespace xengine
 ///////////////////////////////
 // CPeerNet
 
-CPeerNet::CPeerNet(const string& ownKeyIn)
-  : CIOProc(ownKeyIn), confNetwork{}
+CPeerNet::CPeerNet(const string& strOwnKeyIn)
+  : CIOProc(strOwnKeyIn), confNetwork{}
 {
-    RegisterHandler<CPeerNetCloseMessage>(boost::bind(&CPeerNet::HandlePeerNetClose, this, _1));
-    RegisterHandler<CPeerNetRewardMessage>(boost::bind(&CPeerNet::HandlePeerNetReward, this, _1));
+    RegisterRefHandler<CPeerNetCloseMessage>(boost::bind(&CPeerNet::HandlePeerNetClose, this, _1));
+    RegisterRefHandler<CPeerNetRewardMessage>(boost::bind(&CPeerNet::HandlePeerNetReward, this, _1));
 }
 
 CPeerNet::~CPeerNet()

--- a/src/xengine/peernet/peernet.h
+++ b/src/xengine/peernet/peernet.h
@@ -49,7 +49,7 @@ public:
 class CPeerNet : public CIOProc, virtual public CPeerEventListener
 {
 public:
-    CPeerNet(const std::string& ownKeyIn);
+    CPeerNet(const std::string& strOwnKeyIn);
     ~CPeerNet();
     void ConfigNetwork(CPeerNetConfig& config);
     void HandlePeerClose(CPeer* pPeer);

--- a/test/netchn_tests.cpp
+++ b/test/netchn_tests.cpp
@@ -39,8 +39,8 @@ public:
     CDummyPeerNet() {}
     virtual bool HandleInitialize() override
     {
-        RegisterHandler<CPeerNetCloseMessage>(boost::bind(&CDummyPeerNet::HandleNetClose, this, _1));
-        RegisterHandler<CPeerNetRewardMessage>(boost::bind(&CDummyPeerNet::HandleNetReward, this, _1));
+        RegisterRefHandler<CPeerNetCloseMessage>(boost::bind(&CDummyPeerNet::HandleNetClose, this, _1));
+        RegisterRefHandler<CPeerNetRewardMessage>(boost::bind(&CDummyPeerNet::HandleNetReward, this, _1));
         return true;
     }
 

--- a/test/timer_tests.cpp
+++ b/test/timer_tests.cpp
@@ -75,9 +75,9 @@ public:
       : CIOActor("actorA") {}
     virtual bool HandleInitialize() override
     {
-        RegisterHandler<CTimeoutMessageA>(boost::bind(&CActorA::HandlerMessageA, this, _1));
-        RegisterHandler<CTimeoutMessageB>(boost::bind(&CActorA::HandlerMessageB, this, _1));
-        RegisterHandler<CTimeoutMessageC>(boost::bind(&CActorA::HandlerMessageC, this, _1));
+        RegisterRefHandler<CTimeoutMessageA>(boost::bind(&CActorA::HandlerMessageA, this, _1));
+        RegisterRefHandler<CTimeoutMessageB>(boost::bind(&CActorA::HandlerMessageB, this, _1));
+        RegisterRefHandler<CTimeoutMessageC>(boost::bind(&CActorA::HandlerMessageC, this, _1));
         return true;
     }
 
@@ -103,10 +103,10 @@ public:
       : CIOActor("actorB") {}
     virtual bool HandleInitialize() override
     {
-        RegisterHandler<CTimeoutMessageA>(boost::bind(&CActorB::HandlerMessage, this, _1));
-        RegisterHandler<CTimeoutMessageB>(boost::bind(&CActorB::HandlerMessage, this, _1));
-        RegisterHandler<CTimeoutMessageC>(boost::bind(&CActorB::HandlerMessage, this, _1));
-        RegisterHandler<CTimeoutMessageD>(boost::bind(&CActorB::HandlerMessage, this, _1));
+        RegisterRefHandler<CTimeoutMessageA>(boost::bind(&CActorB::HandlerMessage, this, _1));
+        RegisterRefHandler<CTimeoutMessageB>(boost::bind(&CActorB::HandlerMessage, this, _1));
+        RegisterRefHandler<CTimeoutMessageC>(boost::bind(&CActorB::HandlerMessage, this, _1));
+        RegisterRefHandler<CTimeoutMessageD>(boost::bind(&CActorB::HandlerMessage, this, _1));
         return true;
     }
 


### PR DESCRIPTION
- Change string variable name from `ownKey` to `strOwnKey`
- Add `CIOActorWorker` with independent thread for CIOActor, so there could be several actor workers in an actor.
- Split `CIOActor::RegisterHandler` to `CIOActor::RegisterRefHandler` and `CIOActor::RegisterPtrHandler`. Because the message in handler perhaps is delivered to actor worker.
- See actor_tests.cpp for the usage of CIOActorWorker.