### PR TITLE
Fix typo

### DIFF
--- a/script/auto_options.py
+++ b/script/auto_options.py
@@ -1,4 +1,4 @@
-# -*-conding:utf-8-*-
+# -*-coding:utf-8-*-
 
 import sys
 sys.dont_write_bytecode = True

--- a/script/auto_protocol.py
+++ b/script/auto_protocol.py
@@ -1,4 +1,4 @@
-# -*-conding:utf-8-*-
+# -*-coding:utf-8-*-
 import sys
 sys.dont_write_bytecode = True
 

--- a/script/auto_rpc.py
+++ b/script/auto_rpc.py
@@ -1,4 +1,4 @@
-# -*-conding:utf-8-*-
+# -*-coding:utf-8-*-
 
 import sys
 sys.dont_write_bytecode = True

--- a/script/create_json_rpc_wiki.py
+++ b/script/create_json_rpc_wiki.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#-*-conding:utf-8-*-
+#-*-coding:utf-8-*-
 
 import sys
 sys.dont_write_bytecode = True

--- a/script/generator.py
+++ b/script/generator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*-conding:utf-8-*-
+# -*-coding:utf-8-*-
 
 import sys
 sys.dont_write_bytecode = True

--- a/script/tool.py
+++ b/script/tool.py
@@ -1,4 +1,4 @@
-# -*-conding:utf-8-*-
+# -*-coding:utf-8-*-
 import sys
 sys.dont_write_bytecode = True
 

--- a/src/bigbang/base.h
+++ b/src/bigbang/base.h
@@ -54,12 +54,12 @@ public:
 };
 
 class IWorldLineController;
-class IWorldLine : public xengine::IModel
+class IWorldLineModel : public xengine::IModel
 {
     friend class IWorldLineController;
 
 public:
-    IWorldLine()
+    IWorldLineModel()
       : IModel("worldline") {}
 
     virtual void GetForkStatus(std::map<uint256, CForkStatus>& mapForkStatus) = 0;
@@ -113,7 +113,7 @@ public:
     IWorldLineController()
       : CIOActor("worldlinecontroller"), pWorldLine(nullptr) {}
 
-    // TODO: remove these functions because of existed in IWorldLine
+    // TODO: remove these functions because of existed in IWorldLineModel
     virtual Errno AddNewForkContext(const CTransaction& txFork, CForkContext& ctxt) = 0;
     virtual Errno AddNewBlock(const CBlock& block, CWorldLineUpdate& update) = 0;
     virtual Errno AddNewOrigin(const CBlock& block, CWorldLineUpdate& update) = 0;
@@ -162,19 +162,19 @@ protected:
     }
 
 protected:
-    IWorldLine* pWorldLine;
+    IWorldLineModel* pWorldLine;
 };
 
 class ITxPoolController;
-class ITxPool : public xengine::IModel
+class ITxPoolModel : public xengine::IModel
 {
     friend class ITxPoolController;
 
 public:
-    ITxPool()
+    ITxPoolModel()
       : IModel("txpool") {}
 
-    // TODO: remove these functions because of existed in IWorldLine
+    // TODO: remove these functions because of existed in IWorldLineModel
     virtual bool Exists(const uint256& txid) const = 0;
     virtual std::size_t Count(const uint256& fork) const = 0;
     virtual bool Get(const uint256& txid, CTransaction& tx) const = 0;
@@ -235,7 +235,7 @@ protected:
     }
 
 protected:
-    ITxPool* pTxPool;
+    ITxPoolModel* pTxPool;
 };
 
 class IForkManager : public xengine::IBase

--- a/src/bigbang/blockmaker.h
+++ b/src/bigbang/blockmaker.h
@@ -121,9 +121,9 @@ protected:
     std::map<int, CBlockMakerProfile> mapWorkProfile;
     std::map<CDestination, CBlockMakerProfile> mapDelegatedProfile;
     ICoreProtocol* pCoreProtocol;
-    IWorldLineController* pWorldLineCntrl;
+    IWorldLineController* pWorldLineCtrl;
     IForkManager* pForkManager;
-    ITxPoolController* pTxPoolCntrl;
+    ITxPoolController* pTxPoolCtrl;
     IDispatcher* pDispatcher;
     IConsensus* pConsensus;
 };

--- a/src/bigbang/consensus.cpp
+++ b/src/bigbang/consensus.cpp
@@ -176,8 +176,8 @@ bool CDelegateContext::BuildEnrollTx(CTransaction& tx, int nBlockHeight, int64 n
 CConsensus::CConsensus()
 {
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
-    pTxPoolCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
+    pTxPoolCtrl = nullptr;
 }
 
 CConsensus::~CConsensus()
@@ -192,13 +192,13 @@ bool CConsensus::HandleInitialize()
         return false;
     }
 
-    if (!GetObject("worldlinecontroller", pWorldLineCntrl))
+    if (!GetObject("worldlinecontroller", pWorldLineCtrl))
     {
         Error("Failed to request worldline\n");
         return false;
     }
 
-    if (!GetObject("txpoolcontroller", pTxPoolCntrl))
+    if (!GetObject("txpoolcontroller", pTxPoolCtrl))
     {
         Error("Failed to request txpool\n");
         return false;
@@ -228,8 +228,8 @@ void CConsensus::HandleDeinitialize()
     mapContext.clear();
 
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
-    pTxPoolCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
+    pTxPoolCtrl = nullptr;
 }
 
 bool CConsensus::HandleInvoke()
@@ -299,7 +299,7 @@ void CConsensus::PrimaryUpdate(const CWorldLineUpdate& update, const CTxSetChang
 
         CDelegateEnrolled enrolled;
 
-        if (pWorldLineCntrl->GetBlockDelegateEnrolled(hash, enrolled))
+        if (pWorldLineCtrl->GetBlockDelegateEnrolled(hash, enrolled))
         {
             delegate::CDelegateEvolveResult result;
             delegate.Evolve(nBlockHeight, enrolled.mapWeight, enrolled.mapEnrollData, result);
@@ -316,7 +316,7 @@ void CConsensus::PrimaryUpdate(const CWorldLineUpdate& update, const CTxSetChang
 
         CDelegateEnrolled enrolled;
 
-        if (pWorldLineCntrl->GetBlockDelegateEnrolled(hash, enrolled))
+        if (pWorldLineCtrl->GetBlockDelegateEnrolled(hash, enrolled))
         {
             delegate::CDelegateEvolveResult result;
             delegate.Evolve(nBlockHeight, enrolled.mapWeight, enrolled.mapEnrollData, result);
@@ -401,7 +401,7 @@ bool CConsensus::LoadDelegateTx()
     for (map<CDestination, CDelegateContext>::iterator it = mapContext.begin(); it != mapContext.end(); ++it)
     {
         CDelegateTxFilter txFilter((*it).second);
-        if (!pWorldLineCntrl->FilterTx(hashGenesis, txFilter) || !pTxPoolCntrl->FilterTx(hashGenesis, txFilter))
+        if (!pWorldLineCtrl->FilterTx(hashGenesis, txFilter) || !pTxPoolCtrl->FilterTx(hashGenesis, txFilter))
         {
             return false;
         }
@@ -411,7 +411,7 @@ bool CConsensus::LoadDelegateTx()
 
 bool CConsensus::LoadChain()
 {
-    int nLashBlockHeight = pWorldLineCntrl->GetBlockCount(pCoreProtocol->GetGenesisBlockHash()) - 1;
+    int nLashBlockHeight = pWorldLineCtrl->GetBlockCount(pCoreProtocol->GetGenesisBlockHash()) - 1;
     int nStartHeight = nLashBlockHeight - CONSENSUS_ENROLL_INTERVAL + 1;
     if (nStartHeight < 0)
     {
@@ -420,13 +420,13 @@ bool CConsensus::LoadChain()
     for (int i = nStartHeight; i <= nLashBlockHeight; i++)
     {
         uint256 hashBlock;
-        if (!pWorldLineCntrl->GetBlockHash(pCoreProtocol->GetGenesisBlockHash(), i, hashBlock))
+        if (!pWorldLineCtrl->GetBlockHash(pCoreProtocol->GetGenesisBlockHash(), i, hashBlock))
         {
             return false;
         }
         CDelegateEnrolled enrolled;
 
-        if (pWorldLineCntrl->GetBlockDelegateEnrolled(hashBlock, enrolled))
+        if (pWorldLineCtrl->GetBlockDelegateEnrolled(hashBlock, enrolled))
         {
             delegate::CDelegateEvolveResult result;
             delegate.Evolve(i, enrolled.mapWeight, enrolled.mapEnrollData, result);

--- a/src/bigbang/consensus.h
+++ b/src/bigbang/consensus.h
@@ -113,8 +113,8 @@ protected:
 protected:
     boost::mutex mutex;
     ICoreProtocol* pCoreProtocol;
-    IWorldLineController* pWorldLineCntrl;
-    ITxPoolController* pTxPoolCntrl;
+    IWorldLineController* pWorldLineCtrl;
+    ITxPoolController* pTxPoolCtrl;
     delegate::CDelegate delegate;
     std::map<CDestination, CDelegateContext> mapContext;
 };

--- a/src/bigbang/delegatedchn.cpp
+++ b/src/bigbang/delegatedchn.cpp
@@ -226,7 +226,7 @@ bool CDelegatedChannelChain::InsertPublishData(const uint256& hashAnchor, const 
 CDelegatedChannel::CDelegatedChannel()
 {
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
     pDispatcher = nullptr;
     fBulletin = false;
 }
@@ -243,7 +243,7 @@ bool CDelegatedChannel::HandleInitialize()
         return false;
     }
 
-    if (!GetObject("worldlinecontroller", pWorldLineCntrl))
+    if (!GetObject("worldlinecontroller", pWorldLineCtrl))
     {
         Error("Failed to request worldline\n");
         return false;
@@ -268,7 +268,7 @@ bool CDelegatedChannel::HandleInitialize()
 void CDelegatedChannel::HandleDeinitialize()
 {
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
     pDispatcher = nullptr;
 
     DeregisterHandler(CPeerActiveMessage::MessageType());

--- a/src/bigbang/delegatedchn.h
+++ b/src/bigbang/delegatedchn.h
@@ -209,7 +209,7 @@ protected:
 
 protected:
     ICoreProtocol* pCoreProtocol;
-    IWorldLineController* pWorldLineCntrl;
+    IWorldLineController* pWorldLineCtrl;
     IDispatcher* pDispatcher;
     mutable boost::shared_mutex rwPeer;
     xengine::CDataScheduler<CDelegatedDataIdent> schedPeer;

--- a/src/bigbang/dispatcher.h
+++ b/src/bigbang/dispatcher.h
@@ -35,8 +35,8 @@ protected:
 
 protected:
     ICoreProtocol* pCoreProtocol;
-    IWorldLineController* pWorldLineCntrl;
-    ITxPoolController* pTxPoolCntrl;
+    IWorldLineController* pWorldLineCtrl;
+    ITxPoolController* pTxPoolCtrl;
     IForkManager* pForkManager;
     IConsensus* pConsensus;
     IWallet* pWallet;

--- a/src/bigbang/entry.cpp
+++ b/src/bigbang/entry.cpp
@@ -288,7 +288,7 @@ bool CBbEntry::InitializeModules(const EModeType& mode)
         }
         case EModuleType::TXPOOL:
         {
-            if (!AttachModule(new CTxPool()))
+            if (!AttachModule(new CTxPoolModel()))
             {
                 return false;
             }
@@ -322,7 +322,7 @@ bool CBbEntry::InitializeModules(const EModeType& mode)
         }
         case EModuleType::WORLDLINE:
         {
-            if (!AttachModule(new CWorldLine()))
+            if (!AttachModule(new CWorldLineModel()))
             {
                 return false;
             }

--- a/src/bigbang/entry.cpp
+++ b/src/bigbang/entry.cpp
@@ -7,7 +7,6 @@
 #include <map>
 #include <string>
 
-#include "worldline.h"
 #include "blockmaker.h"
 #include "consensus.h"
 #include "core.h"
@@ -25,6 +24,7 @@
 #include "txpool.h"
 #include "version.h"
 #include "wallet.h"
+#include "worldline.h"
 
 #ifdef WIN32
 #ifdef _MSC_VER

--- a/src/bigbang/forkmanager.cpp
+++ b/src/bigbang/forkmanager.cpp
@@ -20,7 +20,7 @@ namespace bigbang
 CForkManager::CForkManager()
 {
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
     fAllowAnyFork = false;
 }
 
@@ -36,7 +36,7 @@ bool CForkManager::HandleInitialize()
         return false;
     }
 
-    if (!GetObject("worldlinecontroller", pWorldLineCntrl))
+    if (!GetObject("worldlinecontroller", pWorldLineCtrl))
     {
         Error("Failed to request worldline\n");
         return false;
@@ -48,7 +48,7 @@ bool CForkManager::HandleInitialize()
 void CForkManager::HandleDeinitialize()
 {
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
 }
 
 bool CForkManager::HandleInvoke()
@@ -121,7 +121,7 @@ bool CForkManager::LoadForkContext(vector<uint256>& vActive)
     boost::unique_lock<boost::shared_mutex> wlock(rwAccess);
 
     vector<CForkContext> vForkCtxt;
-    if (!pWorldLineCntrl->ListForkContext(vForkCtxt))
+    if (!pWorldLineCtrl->ListForkContext(vForkCtxt))
     {
         return false;
     }
@@ -168,7 +168,7 @@ void CForkManager::ForkUpdate(const CWorldLineUpdate& update, vector<uint256>& v
                     && tx.nAmount >= CTemplateFork::LockedCoin(update.nLastBlockHeight))
                 {
                     CForkContext ctxt;
-                    if (pWorldLineCntrl->AddNewForkContext(tx, ctxt) == OK)
+                    if (pWorldLineCtrl->AddNewForkContext(tx, ctxt) == OK)
                     {
                         AddNewForkContext(ctxt, vActive);
                     }
@@ -211,7 +211,7 @@ void CForkManager::ForkUpdate(const CWorldLineUpdate& update, vector<CTransactio
                 {
                     vForkTx.push_back(tx);
                     // CForkContext ctxt;
-                    // if (pWorldLineCntrl->AddNewForkContext(tx, ctxt) == OK)
+                    // if (pWorldLineCtrl->AddNewForkContext(tx, ctxt) == OK)
                     // {
                     //     AddNewForkContext(ctxt, vActive);
                     // }
@@ -239,7 +239,7 @@ bool CForkManager::AddNewForkContext(const CForkContext& ctxt, vector<uint256>& 
         uint256 hashFork = ctxt.hashFork;
         for (;;)
         {
-            if (pWorldLineCntrl->Exists(hashJoint))
+            if (pWorldLineCtrl->Exists(hashJoint))
             {
                 vActive.push_back(hashFork);
                 break;
@@ -253,7 +253,7 @@ bool CForkManager::AddNewForkContext(const CForkContext& ctxt, vector<uint256>& 
             }
 
             CForkContext ctxtParent;
-            if (!pWorldLineCntrl->GetForkContext(hashParent, ctxtParent))
+            if (!pWorldLineCtrl->GetForkContext(hashParent, ctxtParent))
             {
                 return false;
             }
@@ -318,7 +318,7 @@ bool CForkManager::IsAllowedFork(const uint256& hashFork, const uint256& hashPar
         }
         uint256 hash = hashParent;
         CForkContext ctxtParent;
-        while (hash != 0 && pWorldLineCntrl->GetForkContext(hash, ctxtParent))
+        while (hash != 0 && pWorldLineCtrl->GetForkContext(hash, ctxtParent))
         {
             if (setGroupAllowed.count(ctxtParent.hashParent))
             {

--- a/src/bigbang/forkmanager.h
+++ b/src/bigbang/forkmanager.h
@@ -121,7 +121,7 @@ protected:
 protected:
     mutable boost::shared_mutex rwAccess;
     ICoreProtocol* pCoreProtocol;
-    IWorldLineController* pWorldLineCntrl;
+    IWorldLineController* pWorldLineCtrl;
     bool fAllowAnyFork;
     std::set<uint256> setForkAllowed;
     std::set<uint256> setGroupAllowed;

--- a/src/bigbang/mode/module_type.h
+++ b/src/bigbang/mode/module_type.h
@@ -23,10 +23,10 @@ enum class EModuleType
     RPCCLIENT,           // CRPCClient
     RPCMODE,             // CRPCMod
     SERVICE,             // CService
-    TXPOOL,              // CTxPool
+    TXPOOL,              // CTxPoolModel
     TXPOOLCONTROLLER,    // CTxPoolController
     WALLET,              // CWallet
-    WORLDLINE,           // CWorldLine
+    WORLDLINE,           // CWorldLineModel
     WORLDLINECONTROLLER, // CWorldLineController
     CONSENSUS,           // CConsensus
     FORKMANAGER,         // CForkManager

--- a/src/bigbang/netchn.h
+++ b/src/bigbang/netchn.h
@@ -134,8 +134,8 @@ protected:
 protected:
     network::CBbPeerNet* pPeerNet;
     ICoreProtocol* pCoreProtocol;
-    IWorldLineController* pWorldLineCntrl;
-    ITxPoolController* pTxPoolCntrl;
+    IWorldLineController* pWorldLineCtrl;
+    ITxPoolController* pTxPoolCtrl;
     IDispatcher* pDispatcher;
     IService* pService;
 

--- a/src/bigbang/service.h
+++ b/src/bigbang/service.h
@@ -82,8 +82,8 @@ protected:
 
 protected:
     ICoreProtocol* pCoreProtocol;
-    IWorldLineController* pWorldLineCntrl;
-    ITxPoolController* pTxPoolCntrl;
+    IWorldLineController* pWorldLineCtrl;
+    ITxPoolController* pTxPoolCtrl;
     IDispatcher* pDispatcher;
     IWallet* pWallet;
     IForkManager* pForkManager;

--- a/src/bigbang/txpool.cpp
+++ b/src/bigbang/txpool.cpp
@@ -119,7 +119,7 @@ void CTxPoolView::ArrangeBlockTx(vector<CTransaction>& vtx, int64& nTotalTxFee, 
 CTxPool::CTxPool()
 {
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
     nLastSequenceNumber = 0;
 }
 
@@ -140,7 +140,7 @@ bool CTxPool::HandleInitialize()
         return false;
     }
 
-    if (!GetObject("worldlinecontroller", pWorldLineCntrl))
+    if (!GetObject("worldlinecontroller", pWorldLineCtrl))
     {
         Error("Failed to request worldline\n");
         return false;
@@ -152,7 +152,7 @@ bool CTxPool::HandleInitialize()
 void CTxPool::HandleDeinitialize()
 {
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
 
     ITxPool::HandleDeinitialize();
 }
@@ -230,7 +230,7 @@ Errno CTxPool::Push(const CTransaction& tx, uint256& hashFork, CDestination& des
     }
 
     int nHeight;
-    if (!pWorldLineCntrl->GetBlockLocation(tx.hashAnchor, hashFork, nHeight))
+    if (!pWorldLineCtrl->GetBlockLocation(tx.hashAnchor, hashFork, nHeight))
     {
         return ERR_TRANSACTION_INVALID;
     }
@@ -267,7 +267,7 @@ void CTxPool::Pop(const uint256& txid)
     CPooledTx& tx = (*it).second;
     uint256 hashFork;
     int nHeight;
-    if (!pWorldLineCntrl->GetBlockLocation(tx.hashAnchor, hashFork, nHeight))
+    if (!pWorldLineCtrl->GetBlockLocation(tx.hashAnchor, hashFork, nHeight))
     {
         return;
     }
@@ -380,7 +380,7 @@ bool CTxPool::FetchInputs(const uint256& hashFork, const CTransaction& tx, vecto
         txView.GetUnspent(tx.vInput[i].prevout, vUnspent[i]);
     }
 
-    if (!pWorldLineCntrl->GetTxUnspent(hashFork, tx.vInput, vUnspent))
+    if (!pWorldLineCtrl->GetTxUnspent(hashFork, tx.vInput, vUnspent))
     {
         return false;
     }
@@ -567,7 +567,7 @@ Errno CTxPool::AddNew(CTxPoolView& txView, const uint256& txid, const CTransacti
         txView.GetUnspent(tx.vInput[i].prevout, vPrevOutput[i]);
     }
 
-    if (!pWorldLineCntrl->GetTxUnspent(hashFork, tx.vInput, vPrevOutput))
+    if (!pWorldLineCtrl->GetTxUnspent(hashFork, tx.vInput, vPrevOutput))
     {
         return ERR_SYS_STORAGE_ERROR;
     }

--- a/src/bigbang/txpool.cpp
+++ b/src/bigbang/txpool.cpp
@@ -114,22 +114,22 @@ void CTxPoolView::ArrangeBlockTx(vector<CTransaction>& vtx, int64& nTotalTxFee, 
 }
 
 //////////////////////////////
-// CTxPool
+// CTxPoolModel
 
-CTxPool::CTxPool()
+CTxPoolModel::CTxPoolModel()
 {
     pCoreProtocol = nullptr;
     pWorldLineCtrl = nullptr;
     nLastSequenceNumber = 0;
 }
 
-CTxPool::~CTxPool()
+CTxPoolModel::~CTxPoolModel()
 {
 }
 
-bool CTxPool::HandleInitialize()
+bool CTxPoolModel::HandleInitialize()
 {
-    if (!ITxPool::HandleInitialize())
+    if (!ITxPoolModel::HandleInitialize())
     {
         return false;
     }
@@ -149,17 +149,17 @@ bool CTxPool::HandleInitialize()
     return true;
 }
 
-void CTxPool::HandleDeinitialize()
+void CTxPoolModel::HandleDeinitialize()
 {
     pCoreProtocol = nullptr;
     pWorldLineCtrl = nullptr;
 
-    ITxPool::HandleDeinitialize();
+    ITxPoolModel::HandleDeinitialize();
 }
 
-bool CTxPool::HandleInvoke()
+bool CTxPoolModel::HandleInvoke()
 {
-    if (!ITxPool::HandleInvoke())
+    if (!ITxPoolModel::HandleInvoke())
     {
         return false;
     }
@@ -179,7 +179,7 @@ bool CTxPool::HandleInvoke()
     return true;
 }
 
-void CTxPool::HandleHalt()
+void CTxPoolModel::HandleHalt()
 {
     if (!SaveData())
     {
@@ -187,23 +187,23 @@ void CTxPool::HandleHalt()
     }
     Clear();
 
-    ITxPool::HandleHalt();
+    ITxPoolModel::HandleHalt();
 }
 
-bool CTxPool::Exists(const uint256& txid) const
+bool CTxPoolModel::Exists(const uint256& txid) const
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
     return mapTx.count(txid) != 0;
 }
 
-void CTxPool::Clear()
+void CTxPoolModel::Clear()
 {
     boost::unique_lock<boost::shared_mutex> wlock(rwAccess);
     mapPoolView.clear();
     mapTx.clear();
 }
 
-size_t CTxPool::Count(const uint256& fork) const
+size_t CTxPoolModel::Count(const uint256& fork) const
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
     map<uint256, CTxPoolView>::const_iterator it = mapPoolView.find(fork);
@@ -214,7 +214,7 @@ size_t CTxPool::Count(const uint256& fork) const
     return 0;
 }
 
-Errno CTxPool::Push(const CTransaction& tx, uint256& hashFork, CDestination& destIn, int64& nValueIn)
+Errno CTxPoolModel::Push(const CTransaction& tx, uint256& hashFork, CDestination& destIn, int64& nValueIn)
 {
     boost::unique_lock<boost::shared_mutex> wlock(rwAccess);
     uint256 txid = tx.GetHash();
@@ -256,7 +256,7 @@ Errno CTxPool::Push(const CTransaction& tx, uint256& hashFork, CDestination& des
     return err;
 }
 
-void CTxPool::Pop(const uint256& txid)
+void CTxPoolModel::Pop(const uint256& txid)
 {
     boost::unique_lock<boost::shared_mutex> wlock(rwAccess);
     unordered_map<uint256, CPooledTx>::iterator it = mapTx.find(txid);
@@ -282,7 +282,7 @@ void CTxPool::Pop(const uint256& txid)
     }
 }
 
-bool CTxPool::Get(const uint256& txid, CTransaction& tx) const
+bool CTxPoolModel::Get(const uint256& txid, CTransaction& tx) const
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
     unordered_map<uint256, CPooledTx>::const_iterator it = mapTx.find(txid);
@@ -294,7 +294,7 @@ bool CTxPool::Get(const uint256& txid, CTransaction& tx) const
     return false;
 }
 
-void CTxPool::ListTx(const uint256& hashFork, vector<pair<uint256, size_t>>& vTxPool) const
+void CTxPoolModel::ListTx(const uint256& hashFork, vector<pair<uint256, size_t>>& vTxPool) const
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
     map<uint256, CTxPoolView>::const_iterator it = mapPoolView.find(hashFork);
@@ -308,7 +308,7 @@ void CTxPool::ListTx(const uint256& hashFork, vector<pair<uint256, size_t>>& vTx
     }
 }
 
-void CTxPool::ListTx(const uint256& hashFork, vector<uint256>& vTxPool) const
+void CTxPoolModel::ListTx(const uint256& hashFork, vector<uint256>& vTxPool) const
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
     map<uint256, CTxPoolView>::const_iterator it = mapPoolView.find(hashFork);
@@ -322,7 +322,7 @@ void CTxPool::ListTx(const uint256& hashFork, vector<uint256>& vTxPool) const
     }
 }
 
-bool CTxPool::FilterTx(const uint256& hashFork, CTxFilter& filter) const
+bool CTxPoolModel::FilterTx(const uint256& hashFork, CTxFilter& filter) const
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
 
@@ -347,7 +347,7 @@ bool CTxPool::FilterTx(const uint256& hashFork, CTxFilter& filter) const
     return true;
 }
 
-void CTxPool::ArrangeBlockTx(const uint256& hashFork, int64 nBlockTime, size_t nMaxSize,
+void CTxPoolModel::ArrangeBlockTx(const uint256& hashFork, int64 nBlockTime, size_t nMaxSize,
                              vector<CTransaction>& vtx, int64& nTotalTxFee) const
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
@@ -359,7 +359,7 @@ void CTxPool::ArrangeBlockTx(const uint256& hashFork, int64 nBlockTime, size_t n
     }
 }
 
-bool CTxPool::FetchInputs(const uint256& hashFork, const CTransaction& tx, vector<CTxOut>& vUnspent) const
+bool CTxPoolModel::FetchInputs(const uint256& hashFork, const CTransaction& tx, vector<CTxOut>& vUnspent) const
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
     auto it = mapPoolView.find(hashFork);
@@ -406,7 +406,7 @@ bool CTxPool::FetchInputs(const uint256& hashFork, const CTransaction& tx, vecto
     return true;
 }
 
-bool CTxPool::SynchronizeWorldLine(const CWorldLineUpdate& update, CTxSetChange& change)
+bool CTxPoolModel::SynchronizeWorldLine(const CWorldLineUpdate& update, CTxSetChange& change)
 {
     change.hashFork = update.hashFork;
 
@@ -507,7 +507,7 @@ bool CTxPool::SynchronizeWorldLine(const CWorldLineUpdate& update, CTxSetChange&
     return true;
 }
 
-bool CTxPool::LoadData()
+bool CTxPoolModel::LoadData()
 {
     boost::unique_lock<boost::shared_mutex> wlock(rwAccess);
 
@@ -529,7 +529,7 @@ bool CTxPool::LoadData()
     return true;
 }
 
-bool CTxPool::SaveData()
+bool CTxPoolModel::SaveData()
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
 
@@ -554,7 +554,7 @@ bool CTxPool::SaveData()
     return datTxPool.Save(vTx);
 }
 
-Errno CTxPool::AddNew(CTxPoolView& txView, const uint256& txid, const CTransaction& tx, const uint256& hashFork, int nForkHeight)
+Errno CTxPoolModel::AddNew(CTxPoolView& txView, const uint256& txid, const CTransaction& tx, const uint256& hashFork, int nForkHeight)
 {
     vector<CTxOut> vPrevOutput;
     vPrevOutput.resize(tx.vInput.size());

--- a/src/bigbang/txpool.cpp
+++ b/src/bigbang/txpool.cpp
@@ -348,7 +348,7 @@ bool CTxPoolModel::FilterTx(const uint256& hashFork, CTxFilter& filter) const
 }
 
 void CTxPoolModel::ArrangeBlockTx(const uint256& hashFork, int64 nBlockTime, size_t nMaxSize,
-                             vector<CTransaction>& vtx, int64& nTotalTxFee) const
+                                  vector<CTransaction>& vtx, int64& nTotalTxFee) const
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
     auto it = mapPoolView.find(hashFork);

--- a/src/bigbang/txpool.h
+++ b/src/bigbang/txpool.h
@@ -211,11 +211,11 @@ public:
     std::map<CTxOutPoint, CSpent> mapSpent;
 };
 
-class CTxPool : public ITxPool
+class CTxPoolModel : public ITxPoolModel
 {
 public:
-    CTxPool();
-    ~CTxPool();
+    CTxPoolModel();
+    ~CTxPoolModel();
     bool Exists(const uint256& txid) const override;
     std::size_t Count(const uint256& fork) const override;
     bool Get(const uint256& txid, CTransaction& tx) const override;

--- a/src/bigbang/txpool.h
+++ b/src/bigbang/txpool.h
@@ -252,7 +252,7 @@ protected:
     storage::CTxPoolData datTxPool;
     mutable boost::shared_mutex rwAccess;
     ICoreProtocol* pCoreProtocol;
-    IWorldLineController* pWorldLineCntrl;
+    IWorldLineController* pWorldLineCtrl;
     std::map<uint256, CTxPoolView> mapPoolView;
     std::unordered_map<uint256, CPooledTx> mapTx;
     std::size_t nLastSequenceNumber;

--- a/src/bigbang/wallet.cpp
+++ b/src/bigbang/wallet.cpp
@@ -143,8 +143,8 @@ protected:
 CWallet::CWallet()
 {
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
-    pTxPoolCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
+    pTxPoolCtrl = nullptr;
 }
 
 CWallet::~CWallet()
@@ -159,13 +159,13 @@ bool CWallet::HandleInitialize()
         return false;
     }
 
-    if (!GetObject("worldlinecontroller", pWorldLineCntrl))
+    if (!GetObject("worldlinecontroller", pWorldLineCtrl))
     {
         Error("Failed to request worldline\n");
         return false;
     }
 
-    if (!GetObject("txpoolcontroller", pTxPoolCntrl))
+    if (!GetObject("txpoolcontroller", pTxPoolCtrl))
     {
         Error("Failed to request txpool\n");
         return false;
@@ -177,8 +177,8 @@ bool CWallet::HandleInitialize()
 void CWallet::HandleDeinitialize()
 {
     pCoreProtocol = nullptr;
-    pWorldLineCntrl = nullptr;
-    pTxPoolCntrl = nullptr;
+    pWorldLineCtrl = nullptr;
+    pTxPoolCtrl = nullptr;
 }
 
 bool CWallet::HandleInvoke()
@@ -699,7 +699,7 @@ bool CWallet::AddNewFork(const uint256& hashFork, const uint256& hashParent, int
     boost::unique_lock<boost::shared_mutex> wlock(rwWalletTx);
 
     CProfile profile;
-    if (!pWorldLineCntrl->GetForkProfile(hashFork, profile))
+    if (!pWorldLineCtrl->GetForkProfile(hashFork, profile))
     {
         return false;
     }
@@ -791,7 +791,7 @@ bool CWallet::SyncWalletTx(CTxFilter& txFilter)
             vFork.push_back((*mi).second);
         }
 
-        if (!pWorldLineCntrl->FilterTx(hashFork, txFilter) || !pTxPoolCntrl->FilterTx(hashFork, txFilter))
+        if (!pWorldLineCtrl->FilterTx(hashFork, txFilter) || !pTxPoolCtrl->FilterTx(hashFork, txFilter))
         {
             return false;
         }
@@ -817,7 +817,7 @@ bool CWallet::InspectWalletTx(int nCheckDepth)
     }
 
     map<uint256, CForkStatus> mapForkStatus;
-    pWorldLineCntrl->GetForkStatus(mapForkStatus);
+    pWorldLineCtrl->GetForkStatus(mapForkStatus);
     for (const auto& it : mapForkStatus)
     {
         const auto& hashFork = it.first;
@@ -835,7 +835,7 @@ bool CWallet::InspectWalletTx(int nCheckDepth)
         CInspectWtxFilter filterPool(this, setAddr);
         for (const auto& it : vFork)
         {
-            if (!pTxPoolCntrl->FilterTx(it, filterPool)) //condition: fork/dest's
+            if (!pTxPoolCtrl->FilterTx(it, filterPool)) //condition: fork/dest's
             {
                 return false;
             }
@@ -845,7 +845,7 @@ bool CWallet::InspectWalletTx(int nCheckDepth)
         CInspectWtxFilter filterTx(this, setAddr);
         for (const auto& it : vFork)
         {
-            if (!pWorldLineCntrl->FilterTx(it, nDepth, filterTx)) //condition: fork/depth/dest's
+            if (!pWorldLineCtrl->FilterTx(it, nDepth, filterTx)) //condition: fork/depth/dest's
             {
                 return false;
             }
@@ -892,7 +892,7 @@ bool CWallet::CompareWithPoolOrTx(const CWalletTx& wtx, const std::set<CDestinat
     if (wtx.nBlockHeight < 0)
     { //compare wtx with txpool
         CTransaction tx;
-        if (!pTxPoolCntrl->Get(wtx.txid, tx))
+        if (!pTxPoolCtrl->Get(wtx.txid, tx))
         {
             return false;
         }
@@ -907,7 +907,7 @@ bool CWallet::CompareWithPoolOrTx(const CWalletTx& wtx, const std::set<CDestinat
     else
     { //compare wtx with vtx of block
         CTransaction tx;
-        if (!pWorldLineCntrl->GetTransaction(wtx.txid, tx))
+        if (!pWorldLineCtrl->GetTransaction(wtx.txid, tx))
         {
             return false;
         }
@@ -1298,7 +1298,7 @@ bool CWallet::UpdateFork()
     map<uint256, CForkStatus> mapForkStatus;
     multimap<uint256, pair<int, uint256>> mapSubline;
 
-    pWorldLineCntrl->GetForkStatus(mapForkStatus);
+    pWorldLineCtrl->GetForkStatus(mapForkStatus);
 
     for (map<uint256, CForkStatus>::iterator it = mapForkStatus.begin(); it != mapForkStatus.end(); ++it)
     {
@@ -1307,7 +1307,7 @@ bool CWallet::UpdateFork()
         if (!mapFork.count(hashFork))
         {
             CProfile profile;
-            if (!pWorldLineCntrl->GetForkProfile(hashFork, profile))
+            if (!pWorldLineCtrl->GetForkProfile(hashFork, profile))
             {
                 return false;
             }

--- a/src/bigbang/wallet.h
+++ b/src/bigbang/wallet.h
@@ -187,8 +187,8 @@ protected:
 protected:
     storage::CWalletDB dbWallet;
     ICoreProtocol* pCoreProtocol;
-    IWorldLineController* pWorldLineCntrl;
-    ITxPoolController* pTxPoolCntrl;
+    IWorldLineController* pWorldLineCtrl;
+    ITxPoolController* pTxPoolCtrl;
     mutable boost::shared_mutex rwKeyStore;
     mutable boost::shared_mutex rwWalletTx;
     std::map<crypto::CPubKey, CWalletKeyStore> mapKeyStore;

--- a/src/bigbang/worldline.cpp
+++ b/src/bigbang/worldline.cpp
@@ -17,20 +17,20 @@ namespace bigbang
 {
 
 //////////////////////////////
-// CWorldLine
+// CWorldLineModel
 
-CWorldLine::CWorldLine()
+CWorldLineModel::CWorldLineModel()
   : cacheEnrolled(ENROLLED_CACHE_COUNT), cacheAgreement(AGREEMENT_CACHE_COUNT)
 {
     pCoreProtocol = nullptr;
     pTxPoolCtrl = nullptr;
 }
 
-CWorldLine::~CWorldLine()
+CWorldLineModel::~CWorldLineModel()
 {
 }
 
-bool CWorldLine::HandleInitialize()
+bool CWorldLineModel::HandleInitialize()
 {
     if (!GetObject("coreprotocol", pCoreProtocol))
     {
@@ -47,13 +47,13 @@ bool CWorldLine::HandleInitialize()
     return true;
 }
 
-void CWorldLine::HandleDeinitialize()
+void CWorldLineModel::HandleDeinitialize()
 {
     pCoreProtocol = nullptr;
     pTxPoolCtrl = nullptr;
 }
 
-bool CWorldLine::HandleInvoke()
+bool CWorldLineModel::HandleInvoke()
 {
 
     if (!blockBase.Initialize(Config() ? Config()->pathData : "./", Config() ? Config()->fDebug : true))
@@ -88,14 +88,14 @@ bool CWorldLine::HandleInvoke()
     return true;
 }
 
-void CWorldLine::HandleHalt()
+void CWorldLineModel::HandleHalt()
 {
     blockBase.Deinitialize();
     cacheEnrolled.Clear();
     cacheAgreement.Clear();
 }
 
-void CWorldLine::GetForkStatus(map<uint256, CForkStatus>& mapForkStatus)
+void CWorldLineModel::GetForkStatus(map<uint256, CForkStatus>& mapForkStatus)
 {
     mapForkStatus.clear();
 
@@ -122,22 +122,22 @@ void CWorldLine::GetForkStatus(map<uint256, CForkStatus>& mapForkStatus)
     }
 }
 
-bool CWorldLine::GetForkProfile(const uint256& hashFork, CProfile& profile)
+bool CWorldLineModel::GetForkProfile(const uint256& hashFork, CProfile& profile)
 {
     return blockBase.RetrieveProfile(hashFork, profile);
 }
 
-bool CWorldLine::GetForkContext(const uint256& hashFork, CForkContext& ctxt)
+bool CWorldLineModel::GetForkContext(const uint256& hashFork, CForkContext& ctxt)
 {
     return blockBase.RetrieveForkContext(hashFork, ctxt);
 }
 
-bool CWorldLine::GetForkAncestry(const uint256& hashFork, vector<pair<uint256, uint256>> vAncestry)
+bool CWorldLineModel::GetForkAncestry(const uint256& hashFork, vector<pair<uint256, uint256>> vAncestry)
 {
     return blockBase.RetrieveAncestry(hashFork, vAncestry);
 }
 
-int CWorldLine::GetBlockCount(const uint256& hashFork)
+int CWorldLineModel::GetBlockCount(const uint256& hashFork)
 {
     int nCount = 0;
     CBlockIndex* pIndex = nullptr;
@@ -152,7 +152,7 @@ int CWorldLine::GetBlockCount(const uint256& hashFork)
     return nCount;
 }
 
-bool CWorldLine::GetBlockLocation(const uint256& hashBlock, uint256& hashFork, int& nHeight)
+bool CWorldLineModel::GetBlockLocation(const uint256& hashBlock, uint256& hashFork, int& nHeight)
 {
     CBlockIndex* pIndex = nullptr;
     if (!blockBase.RetrieveIndex(hashBlock, &pIndex))
@@ -164,7 +164,7 @@ bool CWorldLine::GetBlockLocation(const uint256& hashBlock, uint256& hashFork, i
     return true;
 }
 
-bool CWorldLine::GetBlockHash(const uint256& hashFork, int nHeight, uint256& hashBlock)
+bool CWorldLineModel::GetBlockHash(const uint256& hashFork, int nHeight, uint256& hashBlock)
 {
     CBlockIndex* pIndex = nullptr;
     if (!blockBase.RetrieveFork(hashFork, &pIndex) || pIndex->GetBlockHeight() < nHeight)
@@ -183,7 +183,7 @@ bool CWorldLine::GetBlockHash(const uint256& hashFork, int nHeight, uint256& has
     return (pIndex != nullptr);
 }
 
-bool CWorldLine::GetBlockHash(const uint256& hashFork, int nHeight, vector<uint256>& vBlockHash)
+bool CWorldLineModel::GetBlockHash(const uint256& hashFork, int nHeight, vector<uint256>& vBlockHash)
 {
     CBlockIndex* pIndex = nullptr;
     if (!blockBase.RetrieveFork(hashFork, &pIndex) || pIndex->GetBlockHeight() < nHeight)
@@ -203,7 +203,7 @@ bool CWorldLine::GetBlockHash(const uint256& hashFork, int nHeight, vector<uint2
     return (!vBlockHash.empty());
 }
 
-bool CWorldLine::GetLastBlock(const uint256& hashFork, uint256& hashBlock, int& nHeight, int64& nTime)
+bool CWorldLineModel::GetLastBlock(const uint256& hashFork, uint256& hashBlock, int& nHeight, int64& nTime)
 {
     CBlockIndex* pIndex = nullptr;
     if (!blockBase.RetrieveFork(hashFork, &pIndex))
@@ -216,7 +216,7 @@ bool CWorldLine::GetLastBlock(const uint256& hashFork, uint256& hashBlock, int& 
     return true;
 }
 
-bool CWorldLine::GetLastBlockTime(const uint256& hashFork, int nDepth, vector<int64>& vTime)
+bool CWorldLineModel::GetLastBlockTime(const uint256& hashFork, int nDepth, vector<int64>& vTime)
 {
     CBlockIndex* pIndex = nullptr;
     if (!blockBase.RetrieveFork(hashFork, &pIndex))
@@ -237,42 +237,42 @@ bool CWorldLine::GetLastBlockTime(const uint256& hashFork, int nDepth, vector<in
     return true;
 }
 
-bool CWorldLine::GetBlock(const uint256& hashBlock, CBlock& block)
+bool CWorldLineModel::GetBlock(const uint256& hashBlock, CBlock& block)
 {
     return blockBase.Retrieve(hashBlock, block);
 }
 
-bool CWorldLine::GetBlockEx(const uint256& hashBlock, CBlockEx& block)
+bool CWorldLineModel::GetBlockEx(const uint256& hashBlock, CBlockEx& block)
 {
     return blockBase.Retrieve(hashBlock, block);
 }
 
-bool CWorldLine::GetOrigin(const uint256& hashFork, CBlock& block)
+bool CWorldLineModel::GetOrigin(const uint256& hashFork, CBlock& block)
 {
     return blockBase.RetrieveOrigin(hashFork, block);
 }
 
-bool CWorldLine::Exists(const uint256& hashBlock)
+bool CWorldLineModel::Exists(const uint256& hashBlock)
 {
     return blockBase.Exists(hashBlock);
 }
 
-bool CWorldLine::GetTransaction(const uint256& txid, CTransaction& tx)
+bool CWorldLineModel::GetTransaction(const uint256& txid, CTransaction& tx)
 {
     return blockBase.RetrieveTx(txid, tx);
 }
 
-bool CWorldLine::ExistsTx(const uint256& txid)
+bool CWorldLineModel::ExistsTx(const uint256& txid)
 {
     return blockBase.ExistsTx(txid);
 }
 
-bool CWorldLine::GetTxLocation(const uint256& txid, uint256& hashFork, int& nHeight)
+bool CWorldLineModel::GetTxLocation(const uint256& txid, uint256& hashFork, int& nHeight)
 {
     return blockBase.RetrieveTxLocation(txid, hashFork, nHeight);
 }
 
-bool CWorldLine::GetTxUnspent(const uint256& hashFork, const vector<CTxIn>& vInput, vector<CTxOut>& vOutput)
+bool CWorldLineModel::GetTxUnspent(const uint256& hashFork, const vector<CTxIn>& vInput, vector<CTxOut>& vOutput)
 {
     vOutput.resize(vInput.size());
     storage::CBlockView view;
@@ -291,22 +291,22 @@ bool CWorldLine::GetTxUnspent(const uint256& hashFork, const vector<CTxIn>& vInp
     return true;
 }
 
-bool CWorldLine::FilterTx(const uint256& hashFork, CTxFilter& filter)
+bool CWorldLineModel::FilterTx(const uint256& hashFork, CTxFilter& filter)
 {
     return blockBase.FilterTx(hashFork, filter);
 }
 
-bool CWorldLine::FilterTx(const uint256& hashFork, int nDepth, CTxFilter& filter)
+bool CWorldLineModel::FilterTx(const uint256& hashFork, int nDepth, CTxFilter& filter)
 {
     return blockBase.FilterTx(hashFork, nDepth, filter);
 }
 
-bool CWorldLine::ListForkContext(vector<CForkContext>& vForkCtxt)
+bool CWorldLineModel::ListForkContext(vector<CForkContext>& vForkCtxt)
 {
     return blockBase.ListForkContext(vForkCtxt);
 }
 
-Errno CWorldLine::AddNewForkContext(const CTransaction& txFork, CForkContext& ctxt)
+Errno CWorldLineModel::AddNewForkContext(const CTransaction& txFork, CForkContext& ctxt)
 {
     uint256 txid = txFork.GetHash();
 
@@ -358,7 +358,7 @@ Errno CWorldLine::AddNewForkContext(const CTransaction& txFork, CForkContext& ct
     return OK;
 }
 
-Errno CWorldLine::AddNewBlock(const CBlock& block, CWorldLineUpdate& update)
+Errno CWorldLineModel::AddNewBlock(const CBlock& block, CWorldLineUpdate& update)
 {
     uint256 hash = block.GetHash();
     Errno err = OK;
@@ -492,7 +492,7 @@ Errno CWorldLine::AddNewBlock(const CBlock& block, CWorldLineUpdate& update)
     return OK;
 }
 
-Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
+Errno CWorldLineModel::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
 {
     uint256 hash = block.GetHash();
     Errno err = OK;
@@ -588,7 +588,7 @@ Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
     return OK;
 }
 
-bool CWorldLine::GetProofOfWorkTarget(const uint256& hashPrev, int nAlgo, int& nBits, int64& nReward)
+bool CWorldLineModel::GetProofOfWorkTarget(const uint256& hashPrev, int nAlgo, int& nBits, int64& nReward)
 {
     CBlockIndex* pIndexPrev;
     if (!blockBase.RetrieveIndex(hashPrev, &pIndexPrev))
@@ -609,7 +609,7 @@ bool CWorldLine::GetProofOfWorkTarget(const uint256& hashPrev, int nAlgo, int& n
     return true;
 }
 
-bool CWorldLine::GetBlockMintReward(const uint256& hashPrev, int64& nReward)
+bool CWorldLineModel::GetBlockMintReward(const uint256& hashPrev, int64& nReward)
 {
     CBlockIndex* pIndexPrev;
     if (!blockBase.RetrieveIndex(hashPrev, &pIndexPrev))
@@ -642,17 +642,17 @@ bool CWorldLine::GetBlockMintReward(const uint256& hashPrev, int64& nReward)
     return true;
 }
 
-bool CWorldLine::GetBlockLocator(const uint256& hashFork, CBlockLocator& locator)
+bool CWorldLineModel::GetBlockLocator(const uint256& hashFork, CBlockLocator& locator)
 {
     return blockBase.GetForkBlockLocator(hashFork, locator);
 }
 
-bool CWorldLine::GetBlockInv(const uint256& hashFork, const CBlockLocator& locator, vector<uint256>& vBlockHash, size_t nMaxCount)
+bool CWorldLineModel::GetBlockInv(const uint256& hashFork, const CBlockLocator& locator, vector<uint256>& vBlockHash, size_t nMaxCount)
 {
     return blockBase.GetForkBlockInv(hashFork, locator, vBlockHash, nMaxCount);
 }
 
-bool CWorldLine::GetBlockDelegateEnrolled(const uint256& hashBlock, CDelegateEnrolled& enrolled)
+bool CWorldLineModel::GetBlockDelegateEnrolled(const uint256& hashBlock, CDelegateEnrolled& enrolled)
 {
     enrolled.Clear();
 
@@ -692,7 +692,7 @@ bool CWorldLine::GetBlockDelegateEnrolled(const uint256& hashBlock, CDelegateEnr
     return true;
 }
 
-bool CWorldLine::GetBlockDelegateAgreement(const uint256& hashBlock, CDelegateAgreement& agreement)
+bool CWorldLineModel::GetBlockDelegateAgreement(const uint256& hashBlock, CDelegateAgreement& agreement)
 {
     agreement.Clear();
 
@@ -747,7 +747,7 @@ bool CWorldLine::GetBlockDelegateAgreement(const uint256& hashBlock, CDelegateAg
     return true;
 }
 
-bool CWorldLine::CheckContainer()
+bool CWorldLineModel::CheckContainer()
 {
     if (blockBase.IsEmpty())
     {
@@ -761,17 +761,17 @@ bool CWorldLine::CheckContainer()
                                       StorageConfig() ? StorageConfig()->nCheckDepth : 1);
 }
 
-bool CWorldLine::RebuildContainer()
+bool CWorldLineModel::RebuildContainer()
 {
     return false;
 }
 
-bool CWorldLine::InsertGenesisBlock(CBlock& block)
+bool CWorldLineModel::InsertGenesisBlock(CBlock& block)
 {
     return blockBase.Initiate(block.GetHash(), block);
 }
 
-Errno CWorldLine::GetTxContxt(storage::CBlockView& view, const CTransaction& tx, CTxContxt& txContxt)
+Errno CWorldLineModel::GetTxContxt(storage::CBlockView& view, const CTransaction& tx, CTxContxt& txContxt)
 {
     txContxt.SetNull();
     for (const CTxIn& txin : tx.vInput)
@@ -794,7 +794,7 @@ Errno CWorldLine::GetTxContxt(storage::CBlockView& view, const CTransaction& tx,
     return OK;
 }
 
-bool CWorldLine::GetBlockChanges(const CBlockIndex* pIndexNew, const CBlockIndex* pIndexFork,
+bool CWorldLineModel::GetBlockChanges(const CBlockIndex* pIndexNew, const CBlockIndex* pIndexFork,
                                  vector<CBlockEx>& vBlockAddNew, vector<CBlockEx>& vBlockRemove)
 {
     while (pIndexNew != pIndexFork)
@@ -824,7 +824,7 @@ bool CWorldLine::GetBlockChanges(const CBlockIndex* pIndexNew, const CBlockIndex
     return true;
 }
 
-bool CWorldLine::GetBlockDelegateAgreement(const uint256& hashBlock, const CBlock& block, const CBlockIndex* pIndexPrev,
+bool CWorldLineModel::GetBlockDelegateAgreement(const uint256& hashBlock, const CBlock& block, const CBlockIndex* pIndexPrev,
                                            CDelegateAgreement& agreement)
 {
     agreement.Clear();
@@ -863,7 +863,7 @@ bool CWorldLine::GetBlockDelegateAgreement(const uint256& hashBlock, const CBloc
     return true;
 }
 
-Errno CWorldLine::VerifyBlock(const uint256& hashBlock, const CBlock& block, CBlockIndex* pIndexPrev, int64& nReward)
+Errno CWorldLineModel::VerifyBlock(const uint256& hashBlock, const CBlock& block, CBlockIndex* pIndexPrev, int64& nReward)
 {
     nReward = 0;
     if (block.IsOrigin())

--- a/src/bigbang/worldline.cpp
+++ b/src/bigbang/worldline.cpp
@@ -23,7 +23,7 @@ CWorldLine::CWorldLine()
   : cacheEnrolled(ENROLLED_CACHE_COUNT), cacheAgreement(AGREEMENT_CACHE_COUNT)
 {
     pCoreProtocol = nullptr;
-    pTxPoolCntrl = nullptr;
+    pTxPoolCtrl = nullptr;
 }
 
 CWorldLine::~CWorldLine()
@@ -38,7 +38,7 @@ bool CWorldLine::HandleInitialize()
         return false;
     }
 
-    if (!GetObject("txpoolcontroller", pTxPoolCntrl))
+    if (!GetObject("txpoolcontroller", pTxPoolCtrl))
     {
         Error("Failed to request txpool\n");
         return false;
@@ -50,13 +50,13 @@ bool CWorldLine::HandleInitialize()
 void CWorldLine::HandleDeinitialize()
 {
     pCoreProtocol = nullptr;
-    pTxPoolCntrl = nullptr;
+    pTxPoolCtrl = nullptr;
 }
 
 bool CWorldLine::HandleInvoke()
 {
 
-    if (!cntrBlock.Initialize(Config() ? Config()->pathData : "./", Config() ? Config()->fDebug : true))
+    if (!blockBase.Initialize(Config() ? Config()->pathData : "./", Config() ? Config()->fDebug : true))
     {
         Error("Failed to initialize container\n");
         return false;
@@ -64,17 +64,17 @@ bool CWorldLine::HandleInvoke()
 
     if (!CheckContainer())
     {
-        cntrBlock.Clear();
+        blockBase.Clear();
         Log("Block container is invalid,try rebuild from block storage\n");
         // Rebuild ...
         if (!RebuildContainer())
         {
-            cntrBlock.Clear();
+            blockBase.Clear();
             Error("Failed to rebuild Block container,reconstruct all\n");
         }
     }
 
-    if (cntrBlock.IsEmpty())
+    if (blockBase.IsEmpty())
     {
         CBlock block;
         pCoreProtocol->GetGenesisBlock(block);
@@ -90,7 +90,7 @@ bool CWorldLine::HandleInvoke()
 
 void CWorldLine::HandleHalt()
 {
-    cntrBlock.Deinitialize();
+    blockBase.Deinitialize();
     cacheEnrolled.Clear();
     cacheAgreement.Clear();
 }
@@ -100,7 +100,7 @@ void CWorldLine::GetForkStatus(map<uint256, CForkStatus>& mapForkStatus)
     mapForkStatus.clear();
 
     multimap<int, CBlockIndex*> mapForkIndex;
-    cntrBlock.ListForkIndex(mapForkIndex);
+    blockBase.ListForkIndex(mapForkIndex);
     for (multimap<int, CBlockIndex*>::iterator it = mapForkIndex.begin(); it != mapForkIndex.end(); ++it)
     {
         CBlockIndex* pIndex = (*it).second;
@@ -124,24 +124,24 @@ void CWorldLine::GetForkStatus(map<uint256, CForkStatus>& mapForkStatus)
 
 bool CWorldLine::GetForkProfile(const uint256& hashFork, CProfile& profile)
 {
-    return cntrBlock.RetrieveProfile(hashFork, profile);
+    return blockBase.RetrieveProfile(hashFork, profile);
 }
 
 bool CWorldLine::GetForkContext(const uint256& hashFork, CForkContext& ctxt)
 {
-    return cntrBlock.RetrieveForkContext(hashFork, ctxt);
+    return blockBase.RetrieveForkContext(hashFork, ctxt);
 }
 
 bool CWorldLine::GetForkAncestry(const uint256& hashFork, vector<pair<uint256, uint256>> vAncestry)
 {
-    return cntrBlock.RetrieveAncestry(hashFork, vAncestry);
+    return blockBase.RetrieveAncestry(hashFork, vAncestry);
 }
 
 int CWorldLine::GetBlockCount(const uint256& hashFork)
 {
     int nCount = 0;
     CBlockIndex* pIndex = nullptr;
-    if (cntrBlock.RetrieveFork(hashFork, &pIndex))
+    if (blockBase.RetrieveFork(hashFork, &pIndex))
     {
         while (pIndex != nullptr)
         {
@@ -155,7 +155,7 @@ int CWorldLine::GetBlockCount(const uint256& hashFork)
 bool CWorldLine::GetBlockLocation(const uint256& hashBlock, uint256& hashFork, int& nHeight)
 {
     CBlockIndex* pIndex = nullptr;
-    if (!cntrBlock.RetrieveIndex(hashBlock, &pIndex))
+    if (!blockBase.RetrieveIndex(hashBlock, &pIndex))
     {
         return false;
     }
@@ -167,7 +167,7 @@ bool CWorldLine::GetBlockLocation(const uint256& hashBlock, uint256& hashFork, i
 bool CWorldLine::GetBlockHash(const uint256& hashFork, int nHeight, uint256& hashBlock)
 {
     CBlockIndex* pIndex = nullptr;
-    if (!cntrBlock.RetrieveFork(hashFork, &pIndex) || pIndex->GetBlockHeight() < nHeight)
+    if (!blockBase.RetrieveFork(hashFork, &pIndex) || pIndex->GetBlockHeight() < nHeight)
     {
         return false;
     }
@@ -186,7 +186,7 @@ bool CWorldLine::GetBlockHash(const uint256& hashFork, int nHeight, uint256& has
 bool CWorldLine::GetBlockHash(const uint256& hashFork, int nHeight, vector<uint256>& vBlockHash)
 {
     CBlockIndex* pIndex = nullptr;
-    if (!cntrBlock.RetrieveFork(hashFork, &pIndex) || pIndex->GetBlockHeight() < nHeight)
+    if (!blockBase.RetrieveFork(hashFork, &pIndex) || pIndex->GetBlockHeight() < nHeight)
     {
         return false;
     }
@@ -206,7 +206,7 @@ bool CWorldLine::GetBlockHash(const uint256& hashFork, int nHeight, vector<uint2
 bool CWorldLine::GetLastBlock(const uint256& hashFork, uint256& hashBlock, int& nHeight, int64& nTime)
 {
     CBlockIndex* pIndex = nullptr;
-    if (!cntrBlock.RetrieveFork(hashFork, &pIndex))
+    if (!blockBase.RetrieveFork(hashFork, &pIndex))
     {
         return false;
     }
@@ -219,7 +219,7 @@ bool CWorldLine::GetLastBlock(const uint256& hashFork, uint256& hashBlock, int& 
 bool CWorldLine::GetLastBlockTime(const uint256& hashFork, int nDepth, vector<int64>& vTime)
 {
     CBlockIndex* pIndex = nullptr;
-    if (!cntrBlock.RetrieveFork(hashFork, &pIndex))
+    if (!blockBase.RetrieveFork(hashFork, &pIndex))
     {
         return false;
     }
@@ -239,44 +239,44 @@ bool CWorldLine::GetLastBlockTime(const uint256& hashFork, int nDepth, vector<in
 
 bool CWorldLine::GetBlock(const uint256& hashBlock, CBlock& block)
 {
-    return cntrBlock.Retrieve(hashBlock, block);
+    return blockBase.Retrieve(hashBlock, block);
 }
 
 bool CWorldLine::GetBlockEx(const uint256& hashBlock, CBlockEx& block)
 {
-    return cntrBlock.Retrieve(hashBlock, block);
+    return blockBase.Retrieve(hashBlock, block);
 }
 
 bool CWorldLine::GetOrigin(const uint256& hashFork, CBlock& block)
 {
-    return cntrBlock.RetrieveOrigin(hashFork, block);
+    return blockBase.RetrieveOrigin(hashFork, block);
 }
 
 bool CWorldLine::Exists(const uint256& hashBlock)
 {
-    return cntrBlock.Exists(hashBlock);
+    return blockBase.Exists(hashBlock);
 }
 
 bool CWorldLine::GetTransaction(const uint256& txid, CTransaction& tx)
 {
-    return cntrBlock.RetrieveTx(txid, tx);
+    return blockBase.RetrieveTx(txid, tx);
 }
 
 bool CWorldLine::ExistsTx(const uint256& txid)
 {
-    return cntrBlock.ExistsTx(txid);
+    return blockBase.ExistsTx(txid);
 }
 
 bool CWorldLine::GetTxLocation(const uint256& txid, uint256& hashFork, int& nHeight)
 {
-    return cntrBlock.RetrieveTxLocation(txid, hashFork, nHeight);
+    return blockBase.RetrieveTxLocation(txid, hashFork, nHeight);
 }
 
 bool CWorldLine::GetTxUnspent(const uint256& hashFork, const vector<CTxIn>& vInput, vector<CTxOut>& vOutput)
 {
     vOutput.resize(vInput.size());
     storage::CBlockView view;
-    if (!cntrBlock.GetForkBlockView(hashFork, view))
+    if (!blockBase.GetForkBlockView(hashFork, view))
     {
         return false;
     }
@@ -293,17 +293,17 @@ bool CWorldLine::GetTxUnspent(const uint256& hashFork, const vector<CTxIn>& vInp
 
 bool CWorldLine::FilterTx(const uint256& hashFork, CTxFilter& filter)
 {
-    return cntrBlock.FilterTx(hashFork, filter);
+    return blockBase.FilterTx(hashFork, filter);
 }
 
 bool CWorldLine::FilterTx(const uint256& hashFork, int nDepth, CTxFilter& filter)
 {
-    return cntrBlock.FilterTx(hashFork, nDepth, filter);
+    return blockBase.FilterTx(hashFork, nDepth, filter);
 }
 
 bool CWorldLine::ListForkContext(vector<CForkContext>& vForkCtxt)
 {
-    return cntrBlock.ListForkContext(vForkCtxt);
+    return blockBase.ListForkContext(vForkCtxt);
 }
 
 Errno CWorldLine::AddNewForkContext(const CTransaction& txFork, CForkContext& ctxt)
@@ -334,7 +334,7 @@ Errno CWorldLine::AddNewForkContext(const CTransaction& txFork, CForkContext& ct
     uint256 hashFork = block.GetHash();
 
     CForkContext ctxtParent;
-    if (!cntrBlock.RetrieveForkContext(profile.hashParent, ctxtParent))
+    if (!blockBase.RetrieveForkContext(profile.hashParent, ctxtParent))
     {
         Log("AddNewForkContext Retrieve parent context Error: %s \n", profile.hashParent.ToString().c_str());
         return ERR_MISSING_PREV;
@@ -349,7 +349,7 @@ Errno CWorldLine::AddNewForkContext(const CTransaction& txFork, CForkContext& ct
     }
 
     ctxt = CForkContext(block.GetHash(), block.hashPrev, txid, profile);
-    if (!cntrBlock.AddNewForkContext(ctxt))
+    if (!blockBase.AddNewForkContext(ctxt))
     {
         Log("AddNewForkContext Already Exists : %s \n", hashFork.ToString().c_str());
         return ERR_ALREADY_HAVE;
@@ -363,7 +363,7 @@ Errno CWorldLine::AddNewBlock(const CBlock& block, CWorldLineUpdate& update)
     uint256 hash = block.GetHash();
     Errno err = OK;
 
-    if (cntrBlock.Exists(hash))
+    if (blockBase.Exists(hash))
     {
         Log("AddNewBlock Already Exists : %s \n", hash.ToString().c_str());
         return ERR_ALREADY_HAVE;
@@ -377,7 +377,7 @@ Errno CWorldLine::AddNewBlock(const CBlock& block, CWorldLineUpdate& update)
     }
 
     CBlockIndex* pIndexPrev;
-    if (!cntrBlock.RetrieveIndex(block.hashPrev, &pIndexPrev))
+    if (!blockBase.RetrieveIndex(block.hashPrev, &pIndexPrev))
     {
         Log("AddNewBlock Retrieve Prev Index Error: %s \n", block.hashPrev.ToString().c_str());
         return ERR_SYS_STORAGE_ERROR;
@@ -393,7 +393,7 @@ Errno CWorldLine::AddNewBlock(const CBlock& block, CWorldLineUpdate& update)
     }
 
     storage::CBlockView view;
-    if (!cntrBlock.GetBlockView(block.hashPrev, view, !block.IsOrigin()))
+    if (!blockBase.GetBlockView(block.hashPrev, view, !block.IsOrigin()))
     {
         Log("AddNewBlock Get Block View Error: %s \n", block.hashPrev.ToString().c_str());
         return ERR_SYS_STORAGE_ERROR;
@@ -433,7 +433,7 @@ Errno CWorldLine::AddNewBlock(const CBlock& block, CWorldLineUpdate& update)
             Log("AddNewBlock Get txContxt Error(%s) : %s \n", ErrorString(err), txid.ToString().c_str());
             return err;
         }
-        if (!pTxPoolCntrl->Exists(txid))
+        if (!pTxPoolCtrl->Exists(txid))
         {
             err = pCoreProtocol->VerifyBlockTx(tx, txContxt, pIndexPrev, nForkHeight, pIndexPrev->GetOriginHash());
             if (err != OK)
@@ -455,7 +455,7 @@ Errno CWorldLine::AddNewBlock(const CBlock& block, CWorldLineUpdate& update)
     }
 
     CBlockIndex* pIndexNew;
-    if (!cntrBlock.AddNew(hash, blockex, &pIndexNew))
+    if (!blockBase.AddNew(hash, blockex, &pIndexNew))
     {
         Log("AddNewBlock Storage AddNew Error : %s \n", hash.ToString().c_str());
         return ERR_SYS_STORAGE_ERROR;
@@ -468,14 +468,14 @@ Errno CWorldLine::AddNewBlock(const CBlock& block, CWorldLineUpdate& update)
     }
 
     CBlockIndex* pIndexFork = nullptr;
-    if (cntrBlock.RetrieveFork(pIndexNew->GetOriginHash(), &pIndexFork)
+    if (blockBase.RetrieveFork(pIndexNew->GetOriginHash(), &pIndexFork)
         && (pIndexFork->nChainTrust > pIndexNew->nChainTrust
             || (pIndexFork->nChainTrust == pIndexNew->nChainTrust && !pIndexNew->IsEquivalent(pIndexFork))))
     {
         return OK;
     }
 
-    if (!cntrBlock.CommitBlockView(view, pIndexNew))
+    if (!blockBase.CommitBlockView(view, pIndexNew))
     {
         Log("AddNewBlock Storage Commit BlockView Error : %s \n", hash.ToString().c_str());
         return ERR_SYS_STORAGE_ERROR;
@@ -497,7 +497,7 @@ Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
     uint256 hash = block.GetHash();
     Errno err = OK;
 
-    if (cntrBlock.Exists(hash))
+    if (blockBase.Exists(hash))
     {
         Log("AddNewOrigin Already Exists : %s \n", hash.ToString().c_str());
         return ERR_ALREADY_HAVE;
@@ -511,14 +511,14 @@ Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
     }
 
     CBlockIndex* pIndexPrev;
-    if (!cntrBlock.RetrieveIndex(block.hashPrev, &pIndexPrev))
+    if (!blockBase.RetrieveIndex(block.hashPrev, &pIndexPrev))
     {
         Log("AddNewOrigin Retrieve Prev Index Error: %s \n", block.hashPrev.ToString().c_str());
         return ERR_SYS_STORAGE_ERROR;
     }
 
     CProfile parent;
-    if (!cntrBlock.RetrieveProfile(pIndexPrev->GetOriginHash(), parent))
+    if (!blockBase.RetrieveProfile(pIndexPrev->GetOriginHash(), parent))
     {
         Log("AddNewOrigin Retrieve parent profile Error: %s \n", block.hashPrev.ToString().c_str());
         return ERR_SYS_STORAGE_ERROR;
@@ -532,7 +532,7 @@ Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
     }
 
     CBlockIndex* pIndexDuplicated;
-    if (cntrBlock.RetrieveFork(profile.strName, &pIndexDuplicated))
+    if (blockBase.RetrieveFork(profile.strName, &pIndexDuplicated))
     {
         Log("AddNewOrigin Validate Origin Error(duplated fork name): %s, \nexisted: %s\n",
             hash.ToString().c_str(), pIndexDuplicated->GetOriginHash().GetHex().c_str());
@@ -543,7 +543,7 @@ Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
 
     if (profile.IsIsolated())
     {
-        if (!cntrBlock.GetBlockView(view))
+        if (!blockBase.GetBlockView(view))
         {
             Log("AddNewOrigin Get Block View Error: %s \n", block.hashPrev.ToString().c_str());
             return ERR_SYS_STORAGE_ERROR;
@@ -551,7 +551,7 @@ Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
     }
     else
     {
-        if (!cntrBlock.GetBlockView(block.hashPrev, view, false))
+        if (!blockBase.GetBlockView(block.hashPrev, view, false))
         {
             Log("AddNewOrigin Get Block View Error: %s \n", block.hashPrev.ToString().c_str());
             return ERR_SYS_STORAGE_ERROR;
@@ -566,7 +566,7 @@ Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
     CBlockIndex* pIndexNew;
     CBlockEx blockex(block);
 
-    if (!cntrBlock.AddNew(hash, blockex, &pIndexNew))
+    if (!blockBase.AddNew(hash, blockex, &pIndexNew))
     {
         Log("AddNewOrigin Storage AddNew Error : %s \n", hash.ToString().c_str());
         return ERR_SYS_STORAGE_ERROR;
@@ -575,7 +575,7 @@ Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
     Log("AddNew Origin Block : %s \n", hash.ToString().c_str());
     Log("    %s\n", pIndexNew->ToString().c_str());
 
-    if (!cntrBlock.CommitBlockView(view, pIndexNew))
+    if (!blockBase.CommitBlockView(view, pIndexNew))
     {
         Log("AddNewOrigin Storage Commit BlockView Error : %s \n", hash.ToString().c_str());
         return ERR_SYS_STORAGE_ERROR;
@@ -591,7 +591,7 @@ Errno CWorldLine::AddNewOrigin(const CBlock& block, CWorldLineUpdate& update)
 bool CWorldLine::GetProofOfWorkTarget(const uint256& hashPrev, int nAlgo, int& nBits, int64& nReward)
 {
     CBlockIndex* pIndexPrev;
-    if (!cntrBlock.RetrieveIndex(hashPrev, &pIndexPrev))
+    if (!blockBase.RetrieveIndex(hashPrev, &pIndexPrev))
     {
         Log("GetProofOfWorkTarget : Retrieve Prev Index Error: %s \n", hashPrev.ToString().c_str());
         return false;
@@ -612,7 +612,7 @@ bool CWorldLine::GetProofOfWorkTarget(const uint256& hashPrev, int nAlgo, int& n
 bool CWorldLine::GetBlockMintReward(const uint256& hashPrev, int64& nReward)
 {
     CBlockIndex* pIndexPrev;
-    if (!cntrBlock.RetrieveIndex(hashPrev, &pIndexPrev))
+    if (!blockBase.RetrieveIndex(hashPrev, &pIndexPrev))
     {
         Log("Get block reward: Retrieve Prev Index Error, hashPrev: %s\n", hashPrev.ToString().c_str());
         return false;
@@ -644,12 +644,12 @@ bool CWorldLine::GetBlockMintReward(const uint256& hashPrev, int64& nReward)
 
 bool CWorldLine::GetBlockLocator(const uint256& hashFork, CBlockLocator& locator)
 {
-    return cntrBlock.GetForkBlockLocator(hashFork, locator);
+    return blockBase.GetForkBlockLocator(hashFork, locator);
 }
 
 bool CWorldLine::GetBlockInv(const uint256& hashFork, const CBlockLocator& locator, vector<uint256>& vBlockHash, size_t nMaxCount)
 {
-    return cntrBlock.GetForkBlockInv(hashFork, locator, vBlockHash, nMaxCount);
+    return blockBase.GetForkBlockInv(hashFork, locator, vBlockHash, nMaxCount);
 }
 
 bool CWorldLine::GetBlockDelegateEnrolled(const uint256& hashBlock, CDelegateEnrolled& enrolled)
@@ -662,7 +662,7 @@ bool CWorldLine::GetBlockDelegateEnrolled(const uint256& hashBlock, CDelegateEnr
     }
 
     CBlockIndex* pIndex;
-    if (!cntrBlock.RetrieveIndex(hashBlock, &pIndex))
+    if (!blockBase.RetrieveIndex(hashBlock, &pIndex))
     {
         Log("GetBlockDelegateEnrolled : Retrieve block Index Error: %s \n", hashBlock.ToString().c_str());
         return false;
@@ -680,7 +680,7 @@ bool CWorldLine::GetBlockDelegateEnrolled(const uint256& hashBlock, CDelegateEnr
         pIndex = pIndex->pPrev;
     }
 
-    if (!cntrBlock.RetrieveAvailDelegate(hashBlock, pIndex->GetBlockHash(), vBlockRange, nDelegateWeightRatio,
+    if (!blockBase.RetrieveAvailDelegate(hashBlock, pIndex->GetBlockHash(), vBlockRange, nDelegateWeightRatio,
                                          enrolled.mapWeight, enrolled.mapEnrollData))
     {
         Log("GetBlockDelegateEnrolled : Retrieve Avail Delegate Error: %s \n", hashBlock.ToString().c_str());
@@ -702,7 +702,7 @@ bool CWorldLine::GetBlockDelegateAgreement(const uint256& hashBlock, CDelegateAg
     }
 
     CBlockIndex* pIndex = nullptr;
-    if (!cntrBlock.RetrieveIndex(hashBlock, &pIndex))
+    if (!blockBase.RetrieveIndex(hashBlock, &pIndex))
     {
         Log("GetBlockDelegateAgreement : Retrieve block Index Error: %s \n", hashBlock.ToString().c_str());
         return false;
@@ -715,7 +715,7 @@ bool CWorldLine::GetBlockDelegateAgreement(const uint256& hashBlock, CDelegateAg
     }
 
     CBlock block;
-    if (!cntrBlock.Retrieve(pIndex, block))
+    if (!blockBase.Retrieve(pIndex, block))
     {
         Log("GetBlockDelegateAgreement : Retrieve block Error: %s \n", hashBlock.ToString().c_str());
         return false;
@@ -749,15 +749,15 @@ bool CWorldLine::GetBlockDelegateAgreement(const uint256& hashBlock, CDelegateAg
 
 bool CWorldLine::CheckContainer()
 {
-    if (cntrBlock.IsEmpty())
+    if (blockBase.IsEmpty())
     {
         return true;
     }
-    if (!cntrBlock.Exists(pCoreProtocol->GetGenesisBlockHash()))
+    if (!blockBase.Exists(pCoreProtocol->GetGenesisBlockHash()))
     {
         return false;
     }
-    return cntrBlock.CheckConsistency(StorageConfig() ? StorageConfig()->nCheckLevel : 1,
+    return blockBase.CheckConsistency(StorageConfig() ? StorageConfig()->nCheckLevel : 1,
                                       StorageConfig() ? StorageConfig()->nCheckDepth : 1);
 }
 
@@ -768,7 +768,7 @@ bool CWorldLine::RebuildContainer()
 
 bool CWorldLine::InsertGenesisBlock(CBlock& block)
 {
-    return cntrBlock.Initiate(block.GetHash(), block);
+    return blockBase.Initiate(block.GetHash(), block);
 }
 
 Errno CWorldLine::GetTxContxt(storage::CBlockView& view, const CTransaction& tx, CTxContxt& txContxt)
@@ -803,7 +803,7 @@ bool CWorldLine::GetBlockChanges(const CBlockIndex* pIndexNew, const CBlockIndex
         if (pIndexNew->GetBlockTime() >= nLastBlockTime)
         {
             CBlockEx block;
-            if (!cntrBlock.Retrieve(pIndexNew, block))
+            if (!blockBase.Retrieve(pIndexNew, block))
             {
                 return false;
             }
@@ -813,7 +813,7 @@ bool CWorldLine::GetBlockChanges(const CBlockIndex* pIndexNew, const CBlockIndex
         else
         {
             CBlockEx block;
-            if (!cntrBlock.Retrieve(pIndexFork, block))
+            if (!blockBase.Retrieve(pIndexFork, block))
             {
                 return false;
             }
@@ -921,7 +921,7 @@ Errno CWorldLine::VerifyBlock(const uint256& hashBlock, const CBlock& block, CBl
         }
 
         CBlockIndex* pIndexRef = nullptr;
-        if (!cntrBlock.RetrieveIndex(proof.hashRefBlock, &pIndexRef))
+        if (!blockBase.RetrieveIndex(proof.hashRefBlock, &pIndexRef))
         {
             return ERR_BLOCK_PROOF_OF_STAKE_INVALID;
         }
@@ -929,7 +929,7 @@ Errno CWorldLine::VerifyBlock(const uint256& hashBlock, const CBlock& block, CBl
         if (block.IsExtended())
         {
             CBlock blockPrev;
-            if (!cntrBlock.Retrieve(pIndexPrev, blockPrev) || blockPrev.IsVacant())
+            if (!blockBase.Retrieve(pIndexPrev, blockPrev) || blockPrev.IsVacant())
             {
                 return ERR_MISSING_PREV;
             }

--- a/src/bigbang/worldline.cpp
+++ b/src/bigbang/worldline.cpp
@@ -795,7 +795,7 @@ Errno CWorldLineModel::GetTxContxt(storage::CBlockView& view, const CTransaction
 }
 
 bool CWorldLineModel::GetBlockChanges(const CBlockIndex* pIndexNew, const CBlockIndex* pIndexFork,
-                                 vector<CBlockEx>& vBlockAddNew, vector<CBlockEx>& vBlockRemove)
+                                      vector<CBlockEx>& vBlockAddNew, vector<CBlockEx>& vBlockRemove)
 {
     while (pIndexNew != pIndexFork)
     {
@@ -825,7 +825,7 @@ bool CWorldLineModel::GetBlockChanges(const CBlockIndex* pIndexNew, const CBlock
 }
 
 bool CWorldLineModel::GetBlockDelegateAgreement(const uint256& hashBlock, const CBlock& block, const CBlockIndex* pIndexPrev,
-                                           CDelegateAgreement& agreement)
+                                                CDelegateAgreement& agreement)
 {
     agreement.Clear();
 

--- a/src/bigbang/worldline.h
+++ b/src/bigbang/worldline.h
@@ -68,8 +68,8 @@ protected:
 
 protected:
     ICoreProtocol* pCoreProtocol;
-    ITxPoolController* pTxPoolCntrl;
-    storage::CBlockBase cntrBlock;
+    ITxPoolController* pTxPoolCtrl;
+    storage::CBlockBase blockBase;
     xengine::CCache<uint256, CDelegateEnrolled> cacheEnrolled;
     xengine::CCache<uint256, CDelegateAgreement> cacheAgreement;
 };

--- a/src/bigbang/worldline.h
+++ b/src/bigbang/worldline.h
@@ -14,11 +14,11 @@
 namespace bigbang
 {
 
-class CWorldLine : public IWorldLine
+class CWorldLineModel : public IWorldLineModel
 {
 public:
-    CWorldLine();
-    ~CWorldLine();
+    CWorldLineModel();
+    ~CWorldLineModel();
     void GetForkStatus(std::map<uint256, CForkStatus>& mapForkStatus) override;
     bool GetForkProfile(const uint256& hashFork, CProfile& profile) override;
     bool GetForkContext(const uint256& hashFork, CForkContext& ctxt) override;

--- a/src/common/template/exchange.cpp
+++ b/src/common/template/exchange.cpp
@@ -129,11 +129,13 @@ bool CTemplateExchange::SetTemplateData(const bigbang::rpc::CTemplateRequest& ob
 
     const string& addr_m = obj.exchange.strAddr_M;
     const string& addr_s = obj.exchange.strAddr_S;
-    if (!destInstance.ParseString(addr_m)) {
+    if (!destInstance.ParseString(addr_m))
+    {
         return false;
     }
     destSpend_m = destInstance;
-    if (!destInstance.ParseString(addr_s)) {
+    if (!destInstance.ParseString(addr_s))
+    {
         return false;
     }
     destSpend_s = destInstance;

--- a/src/xengine/base/model.h
+++ b/src/xengine/base/model.h
@@ -22,7 +22,8 @@ public:
 class INetChannelModel : public IModel
 {
 public:
-    INetChannelModel() : IModel("netchannelmodel") {}
+    INetChannelModel()
+      : IModel("netchannelmodel") {}
 };
 
 } // namespace xengine

--- a/src/xengine/message/actor.h
+++ b/src/xengine/message/actor.h
@@ -5,12 +5,12 @@
 #ifndef XENGINE_MESSAGE_ACTOR_H
 #define XENGINE_MESSAGE_ACTOR_H
 
+#include <boost/any.hpp>
 #include <boost/asio.hpp>
 #include <boost/function.hpp>
-#include <boost/any.hpp>
 #include <memory>
-#include <type_traits>
 #include <set>
+#include <type_traits>
 
 #include "base/controller.h"
 #include "message/actorworker.h"
@@ -116,7 +116,6 @@ private:
     void HandlerThreadFunc();
     /// Message handler callback entry.
     void MessageHandler(std::shared_ptr<CMessage> spMessage);
-
 };
 
 } // namespace xengine

--- a/src/xengine/message/message.h
+++ b/src/xengine/message/message.h
@@ -76,42 +76,42 @@ protected:
  * @brief Create the virtual function of class derived from CMessage: Type() and destructor.
  * @param cls Derived class name.
  */
-#define GENERATE_MESSAGE_FUNCTION(cls)                                                            \
-    template <typename... Args>                                                                   \
-    static std::shared_ptr<cls> Create(Args&&... args)                                            \
-    {                                                                                             \
-        return std::make_shared<cls>(std::forward<Args>(args)...);                                \
-    }                                                                                             \
-    static uint32 MessageType()                                                                   \
-    {                                                                                             \
-        static const uint32 nType = CMessage::NewMessageType();                                   \
-        return nType;                                                                             \
-    }                                                                                             \
-    static std::string MessageTag()                                                               \
-    {                                                                                             \
-        static const std::string strTag = #cls;                                                   \
-        return strTag;                                                                            \
-    }                                                                                             \
-    virtual uint32 Type() const override                                                          \
-    {                                                                                             \
-        return cls::MessageType();                                                                \
-    }                                                                                             \
-    virtual std::string Tag() const override                                                      \
-    {                                                                                             \
-        return cls::MessageTag();                                                                 \
-    }                                                                                             \
-    virtual void Handle(boost::any handler) override                                              \
-    {                                                                                             \
-        try                                                                                       \
-        {                                                                                         \
+#define GENERATE_MESSAGE_FUNCTION(cls)                                                             \
+    template <typename... Args>                                                                    \
+    static std::shared_ptr<cls> Create(Args&&... args)                                             \
+    {                                                                                              \
+        return std::make_shared<cls>(std::forward<Args>(args)...);                                 \
+    }                                                                                              \
+    static uint32 MessageType()                                                                    \
+    {                                                                                              \
+        static const uint32 nType = CMessage::NewMessageType();                                    \
+        return nType;                                                                              \
+    }                                                                                              \
+    static std::string MessageTag()                                                                \
+    {                                                                                              \
+        static const std::string strTag = #cls;                                                    \
+        return strTag;                                                                             \
+    }                                                                                              \
+    virtual uint32 Type() const override                                                           \
+    {                                                                                              \
+        return cls::MessageType();                                                                 \
+    }                                                                                              \
+    virtual std::string Tag() const override                                                       \
+    {                                                                                              \
+        return cls::MessageTag();                                                                  \
+    }                                                                                              \
+    virtual void Handle(boost::any handler) override                                               \
+    {                                                                                              \
+        try                                                                                        \
+        {                                                                                          \
             auto f = boost::any_cast<boost::function<void(const std::shared_ptr<cls>&)>>(handler); \
-            f(SharedFromBase<cls>());                                                             \
-        }                                                                                         \
-        catch (const boost::bad_any_cast&)                                                          \
-        {                                                                                         \
-            auto f = boost::any_cast<boost::function<void(const cls&)>>(handler);                 \
-            f(*this);                                                                             \
-        }                                                                                         \
+            f(SharedFromBase<cls>());                                                              \
+        }                                                                                          \
+        catch (const boost::bad_any_cast&)                                                         \
+        {                                                                                          \
+            auto f = boost::any_cast<boost::function<void(const cls&)>>(handler);                  \
+            f(*this);                                                                              \
+        }                                                                                          \
     }
 
 } // namespace xengine

--- a/src/xengine/message/messagecenter.cpp
+++ b/src/xengine/message/messagecenter.cpp
@@ -6,8 +6,8 @@
 
 #include <memory>
 
-#include "message/actor.h"
 #include "logger.h"
+#include "message/actor.h"
 
 namespace xengine
 {

--- a/test/network_tests.cpp
+++ b/test/network_tests.cpp
@@ -148,9 +148,9 @@ BOOST_AUTO_TEST_CASE(netchn_msg)
     BOOST_CHECK(docker.Attach(new CForkManager()));
     BOOST_CHECK(docker.Attach(new CWallet()));
     BOOST_CHECK(docker.Attach(new CService()));
-    BOOST_CHECK(docker.Attach(new CTxPool()));
+    BOOST_CHECK(docker.Attach(new CTxPoolModel()));
     BOOST_CHECK(docker.Attach(new CTxPoolController()));
-    BOOST_CHECK(docker.Attach(new CWorldLine()));
+    BOOST_CHECK(docker.Attach(new CWorldLineModel()));
     BOOST_CHECK(docker.Attach(new CWorldLineController()));
     BOOST_CHECK(docker.Attach(new CBlockMaker()));
     BOOST_CHECK(docker.Attach(new CDataStat()));
@@ -281,9 +281,9 @@ BOOST_AUTO_TEST_CASE(delegated_chn_msg)
     BOOST_CHECK(docker.Attach(new CForkManager()));
     BOOST_CHECK(docker.Attach(new CWallet()));
     BOOST_CHECK(docker.Attach(new CService()));
-    BOOST_CHECK(docker.Attach(new CTxPool()));
+    BOOST_CHECK(docker.Attach(new CTxPoolModel()));
     BOOST_CHECK(docker.Attach(new CTxPoolController()));
-    BOOST_CHECK(docker.Attach(new CWorldLine()));
+    BOOST_CHECK(docker.Attach(new CWorldLineModel()));
     BOOST_CHECK(docker.Attach(new CWorldLineController()));
     BOOST_CHECK(docker.Attach(new CBlockMaker()));
     BOOST_CHECK(docker.Attach(new CDataStat()));
@@ -362,9 +362,9 @@ BOOST_AUTO_TEST_CASE(peernet_msg)
     BOOST_CHECK(docker.Attach(new CForkManager()));
     BOOST_CHECK(docker.Attach(new CWallet()));
     BOOST_CHECK(docker.Attach(new CService()));
-    BOOST_CHECK(docker.Attach(new CTxPool()));
+    BOOST_CHECK(docker.Attach(new CTxPoolModel()));
     BOOST_CHECK(docker.Attach(new CTxPoolController()));
-    BOOST_CHECK(docker.Attach(new CWorldLine()));
+    BOOST_CHECK(docker.Attach(new CWorldLineModel()));
     BOOST_CHECK(docker.Attach(new CWorldLineController()));
     BOOST_CHECK(docker.Attach(new CBlockMaker()));
     BOOST_CHECK(docker.Attach(new CDataStat()));


### PR DESCRIPTION
 - Change the abbreviation of 'controller' from 'cntrl' to 'ctrl'.
 - Change 'cntrBlock' to 'blockBase'.
 - Add suffix 'Model' after names of derived class of IModel.
 - Execute clang-format for all code file.