### PR TITLE
Unify nonce 

### DIFF
--- a/src/bigbang/netchn.cpp
+++ b/src/bigbang/netchn.cpp
@@ -1004,7 +1004,7 @@ void CNetChannelController::HandleAddedNewBlock(const CAddedBlockMessage& addedM
     const uint256& hashFork = addedMsg.hashFork;
     const CBlock& block = addedMsg.block;
     const uint256& hashBlock = addedMsg.block.GetHash();
-    const uint64& nNonceSender = addedMsg.nNonce;
+    const uint64& nNonceSender = addedMsg.spNonce ? addedMsg.spNonce->nNonce : 0;
     std::vector<uint256> vNextBlockHash;
     set<uint64> setSchedPeer, setMisbehavePeer;
     if (err == OK)
@@ -1041,7 +1041,7 @@ void CNetChannelController::HandleAddedNewBlock(const CAddedBlockMessage& addedM
         {
             auto spAddBlockMsg = CAddBlockMessage::Create();
             spAddBlockMsg->hashFork = hashFork;
-            spAddBlockMsg->nNonce = nNonceSenderTemp;
+            spAddBlockMsg->spNonce = CNonce::Create(nNonceSenderTemp);
             spAddBlockMsg->block = *pBlock;
             PUBLISH_MESSAGE(spAddBlockMsg);
         }
@@ -1055,7 +1055,7 @@ void CNetChannelController::HandleAddedNewTx(const CAddedTxMessage& addedMsg)
     Errno err = static_cast<Errno>(addedMsg.nError);
     const uint256& hashFork = addedMsg.hashFork;
     const uint256& hashTx = addedMsg.tx.GetHash();
-    const uint64& nNonceSender = addedMsg.nNonce;
+    const uint64& nNonceSender = addedMsg.spNonce ? addedMsg.spNonce->nNonce : 0;
     std::vector<uint256> vNextTxChain;
     set<uint64> setSchedPeer, setMisbehavePeer;
     if (err == OK)
@@ -1086,7 +1086,7 @@ void CNetChannelController::HandleAddedNewTx(const CAddedTxMessage& addedMsg)
         if (pTx)
         {
             auto spAddTxMsg = CAddTxMessage::Create();
-            spAddTxMsg->nNonce = nNonceSenderTemp;
+            spAddTxMsg->spNonce = CNonce::Create(nNonceSenderTemp);
             spAddTxMsg->hashFork = hashFork;
             spAddTxMsg->tx = *pTx;
             PUBLISH_MESSAGE(spAddTxMsg);
@@ -1228,7 +1228,7 @@ void CNetChannelController::AddNewBlock(const uint256& hashFork, const uint256& 
             auto spAddNewBlockMsg = CAddBlockMessage::Create();
             spAddNewBlockMsg->block = *pBlock;
             spAddNewBlockMsg->hashFork = hashFork;
-            spAddNewBlockMsg->nNonce = nNonceSender;
+            spAddNewBlockMsg->spNonce = CNonce::Create(nNonceSender);
             PUBLISH_MESSAGE(spAddNewBlockMsg);
         }
     }
@@ -1254,7 +1254,7 @@ void CNetChannelController::AddNewTx(const uint256& hashFork, const uint256& txi
             else
             {
                 auto spAddTxMsg = CAddTxMessage::Create();
-                spAddTxMsg->nNonce = nNonceSender;
+                spAddTxMsg->spNonce = CNonce::Create(nNonceSender);
                 spAddTxMsg->hashFork = hashFork;
                 spAddTxMsg->tx = *pTx;
                 PUBLISH_MESSAGE(spAddTxMsg);

--- a/src/bigbang/txpool/txpoolcontroller.cpp
+++ b/src/bigbang/txpool/txpoolcontroller.cpp
@@ -137,6 +137,8 @@ bool CTxPoolController::SynchronizeWorldLine(const CWorldLineUpdate& update, CTx
 void CTxPoolController::HandleAddTx(const CAddTxMessage& msg)
 {
     auto spAddedMsg = CAddedTxMessage::Create();
+    spAddedMsg->spNonce = msg.spNonce;
+    spAddedMsg->tx = msg.tx;
 
     Push(msg.tx, spAddedMsg->hashFork, spAddedMsg->destIn, spAddedMsg->nValueIn);
 

--- a/src/bigbang/worldline.cpp
+++ b/src/bigbang/worldline.cpp
@@ -1015,7 +1015,6 @@ Errno CWorldLineController::AddNewBlock(const CBlock& block, CWorldLineUpdate& u
     Errno err = AddNewBlockIntoWorldLine(block, update);
 
     auto spAddedBlockMsg = CAddedBlockMessage::Create();
-    spAddedBlockMsg->nNonce = nNonce;
     spAddedBlockMsg->hashFork = update.hashFork;
     spAddedBlockMsg->block = block;
     spAddedBlockMsg->update = update;
@@ -1030,7 +1029,6 @@ Errno CWorldLineController::AddNewOrigin(const CBlock& block, CWorldLineUpdate& 
     Errno err = AddNewOriginIntoWorldLine(block, update);
 
     auto spAddedBlockMsg = CAddedBlockMessage::Create();
-    spAddedBlockMsg->nNonce = nNonce;
     spAddedBlockMsg->hashFork = update.hashFork;
     spAddedBlockMsg->block = block;
     spAddedBlockMsg->update = update;
@@ -1177,9 +1175,15 @@ bool CWorldLineController::GetBlockDelegateAgreement(const uint256& hashBlock, C
 
 void CWorldLineController::HandleAddBlock(const CAddBlockMessage& msg)
 {
+    if (msg.spNonce && !msg.spNonce->fValid)
+    {
+        TRACE("Discard a new block of invalid nonce (%u)", msg.spNonce->nNonce);
+        return;
+    }
+
     // Add new block
     auto spAddedBlockMsg = CAddedBlockMessage::Create();
-    spAddedBlockMsg->nNonce = msg.nNonce;
+    spAddedBlockMsg->spNonce = msg.spNonce;
     spAddedBlockMsg->hashFork = msg.hashFork;
     spAddedBlockMsg->block = msg.block;
 
@@ -1226,7 +1230,6 @@ void CWorldLineController::HandleAddBlock(const CAddBlockMessage& msg)
                 if (err == OK)
                 {
                     spAddedOriginMsg->nError = OK;
-                    spAddedOriginMsg->nNonce = 0;
                     spAddedOriginMsg->hashFork = originBlock.GetHash();
                     PUBLISH_MESSAGE(spAddedOriginMsg);
                 }

--- a/src/common/message.h
+++ b/src/common/message.h
@@ -205,7 +205,7 @@ struct CPeerPublishMessageOutBound : public CPeerPublishMessageInBound
 struct CAddTxMessage : public xengine::CMessage
 {
     GENERATE_MESSAGE_FUNCTION(CAddTxMessage);
-    uint64 nNonce;
+    std::shared_ptr<CNonce> spNonce;
     uint256 hashFork;
     CTransaction tx;
 };
@@ -214,7 +214,7 @@ struct CAddTxMessage : public xengine::CMessage
 struct CAddedTxMessage : public xengine::CMessage
 {
     GENERATE_MESSAGE_FUNCTION(CAddedTxMessage);
-    uint64 nNonce;
+    std::shared_ptr<CNonce> spNonce;
     int nError;
     uint256 hashFork;
     CTransaction tx;
@@ -251,7 +251,7 @@ struct CSyncTxChangeMessage : public xengine::CMessage
 struct CAddBlockMessage : public xengine::CMessage
 {
     GENERATE_MESSAGE_FUNCTION(CAddBlockMessage);
-    uint64 nNonce;
+    std::shared_ptr<CNonce> spNonce;
     uint256 hashFork;
     CBlock block;
 };
@@ -260,7 +260,7 @@ struct CAddBlockMessage : public xengine::CMessage
 struct CAddedBlockMessage : public xengine::CMessage
 {
     GENERATE_MESSAGE_FUNCTION(CAddedBlockMessage);
-    uint64 nNonce;
+    std::shared_ptr<CNonce> spNonce;
     uint256 hashFork;
     CBlock block;
     int nError;

--- a/src/xengine/http/httpserver.cpp
+++ b/src/xengine/http/httpserver.cpp
@@ -10,6 +10,8 @@
 using namespace std;
 using boost::asio::ip::tcp;
 
+static const uint8 HTTP_NONCE_TYPE = 0x0F;
+
 namespace xengine
 {
 
@@ -377,12 +379,11 @@ bool CHttpServer::ClientAccepted(const tcp::endpoint& epService, CIOClient* pCli
 
 CHttpClient* CHttpServer::AddNewClient(CIOClient* pClient, CHttpProfile* pHttpProfile)
 {
-    uint64 nNonce = 0;
-    RAND_bytes((unsigned char*)&nNonce, sizeof(nNonce));
-    while (mapClient.count(nNonce))
+    uint64 nNonce;
+    do
     {
-        RAND_bytes((unsigned char*)&nNonce, sizeof(nNonce));
-    }
+        nNonce = CreateNonce(HTTP_NONCE_TYPE);
+    } while (mapClient.count(nNonce));
 
     CHttpClient* pHttpClient = new CHttpClient(this, pHttpProfile, pClient, nNonce);
     if (pHttpClient != nullptr)

--- a/src/xengine/peernet/peernet.cpp
+++ b/src/xengine/peernet/peernet.cpp
@@ -16,6 +16,8 @@ using boost::asio::ip::tcp;
 
 #define CONNECT_TIMEOUT 10
 
+static const uint8 PEER_NONCE_TYPE = 0xFF;
+
 namespace xengine
 {
 
@@ -212,11 +214,10 @@ void CPeerNet::HostResolved(const CNetHost& host, const tcp::endpoint& ep)
 CPeer* CPeerNet::AddNewPeer(CIOClient* pClient, bool fInBound)
 {
     uint64 nNonce;
-    RAND_bytes((unsigned char*)&nNonce, sizeof(nNonce));
-    while (mapPeer.count(nNonce) || nNonce <= 0xFF)
+    do
     {
-        RAND_bytes((unsigned char*)&nNonce, sizeof(nNonce));
-    }
+        nNonce = CreateNonce(PEER_NONCE_TYPE);
+    } while (mapPeer.count(nNonce));
 
     CPeer* pPeer = CreatePeer(pClient, nNonce, fInBound);
     if (pPeer != nullptr)


### PR DESCRIPTION
Unify nonce type, generator and judgement. Class CNonce is designed for asynchronous judgement that the nonce is valid or not.