### PR TITLE
Optimize RPC listunspent

### DIFF
--- a/script/auto_protocol.py
+++ b/script/auto_protocol.py
@@ -35,7 +35,9 @@ def subclass_name(name, named=False):
 def param_name(name, type):
     if type == 'int' or type == 'uint':
         return 'n' + name.title()
-    elif type == 'double' or type == 'bool':
+    elif type == 'double':
+        return 'd' + name.title()
+    elif type == 'bool':
         return 'f' + name.title()
     elif type == 'array':
         return 'vec' + name.title()
@@ -1423,7 +1425,7 @@ class Response:
         self.content = content
 
     def parse(self):
-        prefix = join_prefix(self.cmd, 'request')
+        prefix = join_prefix(self.cmd, 'response')
 
         self.type, self.reference, self.ref_cls = get_type(prefix, self.content)
 

--- a/script/template/rpc.json
+++ b/script/template/rpc.json
@@ -1,39 +1,27 @@
 {
-    "unspentpresent": {
+    "unspentdata": {
         "type": "class",
-        "name": "UnspentPresent",
+        "name": "UnspentData",
         "content": {
             "txid": {
                 "type": "string",
                 "desc": "txid"
             },
-            "vout": {
+            "out": {
                 "type": "uint",
                 "desc": "tx output point"
-            },
-            "to": {
-                "type": "string",
-                "desc": "address to receive tokens"
             },
             "amount": {
                 "type": "double",
                 "desc": "amount"
             },
-            "txtime": {
+            "time": {
                 "type": "uint",
                 "desc": "time transaction made"
             },
             "lockuntil": {
                 "type": "uint",
                 "desc": "lockuntil"
-            },
-            "forkid": {
-                "type": "string",
-                "desc": "forkid"
-            },
-            "accumulate": {
-                "type": "double",
-                "desc": "accumulated amount"
             }
         }
     },
@@ -2803,53 +2791,56 @@
         "request": {
             "type": "object",
             "content": {
-                "forkid": {
+                "address": {
                     "type": "string",
-                    "desc": "in which of forks transaction occurs",
-                    "opt" : "f"
+                    "desc": "address to receive the unspent"
                 },
-                "addr": {
+                "fork": {
                     "type": "string",
-                    "desc": "address to receive the unspent utxo",
-                    "opt" : "a"
-                },
-                "sum": {
-                    "type": "bool",
-                    "desc": "whether to summary amount",
-                    "opt" : "s",
-                    "default": true,
-                    "required": true
+                    "desc": "fork hash",
+                    "opt" : "f",
+                    "required" : false
                 },
                 "max": {
-                    "type": "int",
-                    "desc": "maximum unspents(3 by default)",
+                    "type": "uint",
+                    "desc": "maximum unspents(0 means unlimited)",
                     "opt" : "n",
+                    "default": 3,
                     "required" : false
                 }
             }
         },
         "response": {
-            "type": "array",
-            "name": "unspents",
+            "type": "object",
+            "name": "data",
             "content": {
                 "unspents": {
-                    "type": "unspentpresent",
-                    "desc": "unspent list of address owner"
+                    "type": "array",
+                    "desc": "unspent list of address owner",
+                    "content": {
+                        "unspent": {
+                            "type": "unspentdata",
+                            "desc": "unspent data"
+                        }
+                    }
+                },
+                "sum": {
+                    "type": "double",
+                    "desc": "sum of unspent amount"
                 }
             }
         },
         "example": [
             {
-                "request": "bigbang-cli listunspent -s=true -f=00000000dcde418dca150e49f53ab857d5ccd095a800bfb29ea87385267bc069 -a=1dfh32vsa73hagmafr2hbmktbhat286hd7qp7hm118ksfqnfjfbentdv5",
-                "response": "[{\"txid\":\"5dc933e8de7212fe051ee97232ae3d14cb4b5474174b45d1f28b91a8c852853a\",\"vout\":0,\"to\":\"1dfh32vsa73hagmafr2hbmktbhat286hd7qp7hm118ksfqnfjfbentdv5\",\"amount\":0.000001,\"txtime\":1573467112,\"lockuntil\":0,\"forkid\":\"00000000dcde418dca150e49f53ab857d5ccd095a800bfb29ea87385267bc069\",\"accumulate\":0.000001},{\"txid\":\"5dc94645f8842b3aa0281fcf380f49df77189a535ed87196ac3a01e15e877f4a\",\"vout\":0,\"to\":\"1dfh32vsa73hagmafr2hbmktbhat286hd7qp7hm118ksfqnfjfbentdv5\",\"amount\":1.000000,\"txtime\":1573471813,\"lockuntil\":0,\"forkid\":\"00000000dcde418dca150e49f53ab857d5ccd095a800bfb29ea87385267bc069\",\"accumulate\":1.000001},{\"txid\":\"5dc945d730c57f9f36d9a10bf1b8c21b76d25aa92df21e04205d73320d9d14d2\",\"vout\":0,\"to\":\"1dfh32vsa73hagmafr2hbmktbhat286hd7qp7hm118ksfqnfjfbentdv5\",\"amount\":0.001000,\"txtime\":1573471703,\"lockuntil\":0,\"forkid\":\"00000000dcde418dca150e49f53ab857d5ccd095a800bfb29ea87385267bc069\",\"accumulate\":1.001001}]"
+                "request": "bigbang-cli listunspent 1965p604xzdrffvg90ax9bk0q3xyqn5zz2vc9zpbe3wdswzazj7d144mm -f=00000000beb6f9e2a8813f4778b26820a8649894de63624e65bc0ffa9562730b -n=1",
+                "response": "{\"unspents\":[{\"txid\":\"5dd4bb56b3d0aed9bb0e0a80d01ec1f70d7bd4d1fc200a48df330154b366ca8e\",\"out\":0,\"amount\":1000.000000,\"time\":1574222678,\"lockuntil\":0}],\"sum\":1000.000000}"
             },
             {
-                "request": "curl -d '{\"id\":1,\"method\":\"listunspent\",\"jsonrpc\":\"2.0\",\"params\":{\"forkid\":\"00000000dcde418dca150e49f53ab857d5ccd095a800bfb29ea87385267bc069\",\"addr\":\"1dfh32vsa73hagmafr2hbmktbhat286hd7qp7hm118ksfqnfjfbentdv5\",\"max\":3,\"sum\":false}}' http://127.0.0.1:9904",
-                "response": "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":[{\"txid\":\"5dc933e8de7212fe051ee97232ae3d14cb4b5474174b45d1f28b91a8c852853a\",\"vout\":0,\"to\":\"1dfh32vsa73hagmafr2hbmktbhat286hd7qp7hm118ksfqnfjfbentdv5\",\"amount\":0.000001,\"txtime\":1573467112,\"lockuntil\":0,\"forkid\":\"00000000dcde418dca150e49f53ab857d5ccd095a800bfb29ea87385267bc069\",\"accumulate\":0.000000},{\"txid\":\"5dc94645f8842b3aa0281fcf380f49df77189a535ed87196ac3a01e15e877f4a\",\"vout\":0,\"to\":\"1dfh32vsa73hagmafr2hbmktbhat286hd7qp7hm118ksfqnfjfbentdv5\",\"amount\":1.000000,\"txtime\":1573471813,\"lockuntil\":0,\"forkid\":\"00000000dcde418dca150e49f53ab857d5ccd095a800bfb29ea87385267bc069\",\"accumulate\":0.000000},{\"txid\":\"5dc945d730c57f9f36d9a10bf1b8c21b76d25aa92df21e04205d73320d9d14d2\",\"vout\":0,\"to\":\"1dfh32vsa73hagmafr2hbmktbhat286hd7qp7hm118ksfqnfjfbentdv5\",\"amount\":0.001000,\"txtime\":1573471703,\"lockuntil\":0,\"forkid\":\"00000000dcde418dca150e49f53ab857d5ccd095a800bfb29ea87385267bc069\",\"accumulate\":0.000000}]}"
+                "request": "curl -d '{\"id\":0,\"method\":\"listunspent\",\"jsonrpc\":\"2.0\",\"params\":{\"address\":\"1965p604xzdrffvg90ax9bk0q3xyqn5zz2vc9zpbe3wdswzazj7d144mm\",\"fork\":\"00000000beb6f9e2a8813f4778b26820a8649894de63624e65bc0ffa9562730b\",\"max\":1}}' http://127.0.0.1:9902",
+                "response": "{\"id\":0,\"jsonrpc\":\"2.0\",\"result\":{\"unspents\":[{\"txid\":\"5dd4bb56b3d0aed9bb0e0a80d01ec1f70d7bd4d1fc200a48df330154b366ca8e\",\"out\":0,\"amount\":1000.000000,\"time\":1574222678,\"lockuntil\":0}],\"sum\":1000.000000}}"
             }
         ],
         "error": [
-            "{\"code\":-401,\"message\":\"nMax must be more than or equal to -1.\"}",
             "{\"code\":-401,\"message\":\"Address as an argument should be provided.\"}",
             "{\"code\":-401,\"message\":\"Acquiring unspent list failed.\"}"
         ]

--- a/src/bigbang/base.h
+++ b/src/bigbang/base.h
@@ -91,7 +91,7 @@ public:
     virtual bool GetBlockMintReward(const uint256& hashPrev, int64& nReward) = 0;
     virtual bool GetBlockLocator(const uint256& hashFork, CBlockLocator& locator, uint256& hashDepth, int nIncStep) = 0;
     virtual bool GetBlockInv(const uint256& hashFork, const CBlockLocator& locator, std::vector<uint256>& vBlockHash, std::size_t nMaxCount) = 0;
-    virtual bool ListForkUnspent(const uint256& forkId, const CDestination& destOwner, int nMax, std::vector<CTxUnspent>& vUnspent) = 0;
+    virtual bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) = 0;
     // virtual bool GetBlockDelegateEnrolled(const uint256& hashBlock, CDelegateEnrolled& enrolled) = 0;
     // virtual bool GetBlockDelegateAgreement(const uint256& hashRefBlock, CDelegateAgreement& agreement) = 0;
     const CBasicConfig* Config()
@@ -206,6 +206,7 @@ public:
     virtual bool GetBalance(const CDestination& dest, const uint256& hashFork, int nForkHeight, CWalletBalance& balance) = 0;
     virtual bool SignTransaction(const CDestination& destIn, CTransaction& tx, bool& fCompleted) const = 0;
     virtual bool ArrangeInputs(const CDestination& destIn, const uint256& hashFork, int nForkHeight, CTransaction& tx) = 0;
+    virtual bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) = 0;
     /* Update */
     virtual bool SynchronizeTxSet(const CTxSetChange& change) = 0;
     virtual bool AddNewTx(const uint256& hashFork, const CAssembledTx& tx) = 0;
@@ -273,7 +274,7 @@ public:
     virtual bool GetTransaction(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight) = 0;
     virtual Errno SendTransaction(CTransaction& tx) = 0;
     virtual bool RemovePendingTx(const uint256& txid) = 0;
-    virtual bool ListForkUnspent(const uint256& forkId, const CDestination& destOwner, int nMax, std::vector<CTxUnspent>& vUnspent) = 0;
+    virtual bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) = 0;
     /* Wallet */
     virtual bool HaveKey(const crypto::CPubKey& pubkey) = 0;
     virtual void GetPubKeys(std::set<crypto::CPubKey>& setPubKey) = 0;

--- a/src/bigbang/blockchain.cpp
+++ b/src/bigbang/blockchain.cpp
@@ -690,9 +690,9 @@ bool CBlockChain::GetBlockInv(const uint256& hashFork, const CBlockLocator& loca
     return cntrBlock.GetForkBlockInv(hashFork, locator, vBlockHash, nMaxCount);
 }
 
-bool CBlockChain::ListForkUnspent(const uint256& forkId, const CDestination& destOwner, int nMax, std::vector<CTxUnspent>& vUnspent)
+bool CBlockChain::ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent)
 {
-    return cntrBlock.ListForkUnspent(forkId, destOwner, nMax, vUnspent);
+    return cntrBlock.ListForkUnspent(hashFork, dest, nMax, vUnspent);
 }
 
 // bool CBlockChain::GetBlockDelegateEnrolled(const uint256& hashBlock, CDelegateEnrolled& enrolled)

--- a/src/bigbang/blockchain.h
+++ b/src/bigbang/blockchain.h
@@ -50,7 +50,7 @@ public:
     bool GetBlockInv(const uint256& hashFork, const CBlockLocator& locator, std::vector<uint256>& vBlockHash, std::size_t nMaxCount) override;
     // bool GetBlockDelegateEnrolled(const uint256& hashBlock, CDelegateEnrolled& enrolled) override;
     // bool GetBlockDelegateAgreement(const uint256& hashBlock, CDelegateAgreement& agreement) override;
-    bool ListForkUnspent(const uint256& forkId, const CDestination& destOwner, int nMax, std::vector<CTxUnspent>& vUnspent) override;
+    bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) override;
 
 protected:
     bool HandleInitialize() override;

--- a/src/bigbang/service.cpp
+++ b/src/bigbang/service.cpp
@@ -352,9 +352,13 @@ bool CService::RemovePendingTx(const uint256& txid)
     return true;
 }
 
-bool CService::ListForkUnspent(const uint256& forkId, const CDestination& destOwner, int nMax, std::vector<CTxUnspent>& vUnspent)
+bool CService::ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent)
 {
-    return pBlockChain->ListForkUnspent(forkId, destOwner, nMax, vUnspent);
+    if (pWallet->ListForkUnspent(hashFork, dest, nMax, vUnspent))
+    {
+        return true;
+    }
+    return pBlockChain->ListForkUnspent(hashFork, dest, nMax, vUnspent);
 }
 
 bool CService::HaveKey(const crypto::CPubKey& pubkey)

--- a/src/bigbang/service.h
+++ b/src/bigbang/service.h
@@ -45,7 +45,7 @@ public:
     bool GetTransaction(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight) override;
     Errno SendTransaction(CTransaction& tx) override;
     bool RemovePendingTx(const uint256& txid) override;
-    bool ListForkUnspent(const uint256& forkId, const CDestination& destOwner, int nMax, std::vector<CTxUnspent>& vUnspent) override;
+    bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) override;
     /* Wallet */
     bool HaveKey(const crypto::CPubKey& pubkey) override;
     void GetPubKeys(std::set<crypto::CPubKey>& setPubKey) override;

--- a/src/bigbang/wallet.h
+++ b/src/bigbang/wallet.h
@@ -147,6 +147,7 @@ public:
     bool GetBalance(const CDestination& dest, const uint256& hashFork, int nForkHeight, CWalletBalance& balance) override;
     bool SignTransaction(const CDestination& destIn, CTransaction& tx, bool& fCompleted) const override;
     bool ArrangeInputs(const CDestination& destIn, const uint256& hashFork, int nForkHeight, CTransaction& tx) override;
+    bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) override;
     /* Update */
     bool SynchronizeTxSet(const CTxSetChange& change) override;
     bool AddNewTx(const uint256& hashFork, const CAssembledTx& tx) override;
@@ -291,6 +292,11 @@ public:
     virtual bool ArrangeInputs(const CDestination& destIn,
                                const uint256& hashFork, int nForkHeight,
                                CTransaction& tx) override
+    {
+        return false;
+    }
+    virtual bool ListForkUnspent(const uint256& hashFork, const CDestination& dest,
+                                 uint32 nMax, std::vector<CTxUnspent>& vUnspent) override
     {
         return false;
     }

--- a/src/storage/blockbase.cpp
+++ b/src/storage/blockbase.cpp
@@ -1613,11 +1613,11 @@ bool CBlockBase::CheckInputSingleAddressForTxWithChange(const uint256& txid)
     }
 }
 
-bool CBlockBase::ListForkUnspent(const uint256& forkId, const CDestination& destOwner, int nMax, std::vector<CTxUnspent>& vUnspent)
+bool CBlockBase::ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent)
 {
     vUnspent.clear();
-    CListUnspentWalker walker(forkId, destOwner, nMax);
-    dbBlock.WalkThroughUnspent(forkId, walker);
+    CListUnspentWalker walker(hashFork, dest, nMax);
+    dbBlock.WalkThroughUnspent(hashFork, walker);
     vUnspent = walker.vUnspent;
     return true;
 }

--- a/src/storage/blockbase.h
+++ b/src/storage/blockbase.h
@@ -252,7 +252,7 @@ public:
     bool GetForkBlockInv(const uint256& hashFork, const CBlockLocator& locator, std::vector<uint256>& vBlockHash, size_t nMaxCount);
     bool CheckConsistency(int nCheckLevel, int nCheckDepth);
     bool CheckInputSingleAddressForTxWithChange(const uint256& txid);
-    bool ListForkUnspent(const uint256& forkId, const CDestination& destOwner, int nMax, std::vector<CTxUnspent>& vUnspent);
+    bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent);
 
 protected:
     CBlockIndex* GetIndex(const uint256& hash) const;

--- a/src/storage/unspentdb.h
+++ b/src/storage/unspentdb.h
@@ -63,11 +63,11 @@ public:
 class CListUnspentWalker : public CForkUnspentDBWalker
 {
 public:
-    CListUnspentWalker(const uint256& forkidIn, const CDestination& destOwnerIn, int maxIn)
+    CListUnspentWalker(const uint256& forkidIn, const CDestination& destOwnerIn, uint32 maxIn)
       : forkId(forkidIn), destOwner(destOwnerIn), nMax(maxIn), nCounter(0) {}
     bool Walk(const CTxOutPoint& txout, const CTxOut& output) override
     {
-        if (nMax > -1 && nCounter >= nMax)
+        if (nMax != 0 && nCounter >= nMax)
         {
             return false; //exit walk through processing
         }
@@ -82,8 +82,8 @@ public:
 public:
     const uint256& forkId;
     const CDestination& destOwner;
-    int nMax;
-    int nCounter;
+    uint32 nMax;
+    uint32 nCounter;
     std::vector<CTxUnspent> vUnspent;
 };
 


### PR DESCRIPTION
1. Optimize RPC listunspent input/output params, and support list unspent of wallet key

2. Fix auto protocol script: double variable name begins with "d"

Part of  #280 