### PR TITLE
Fix DVP leak: bad length vector of stream.

### DIFF
--- a/src/common/proof.h
+++ b/src/common/proof.h
@@ -10,6 +10,7 @@
 #include "destination.h"
 #include "key.h"
 #include "uint256.h"
+#include "util.h"
 
 class CProofOfSecretShare
 {
@@ -30,7 +31,15 @@ public:
             return false;
         }
         xengine::CIDataStream is(vchProof);
-        FromStream(is);
+        try
+        {
+            FromStream(is);
+        }
+        catch(const std::exception& e)
+        {
+            xengine::StdError(__PRETTY_FUNCTION__, e.what());
+            return false;
+        }
         return true;
     }
     size_t size()

--- a/src/common/template/exchange.cpp
+++ b/src/common/template/exchange.cpp
@@ -177,7 +177,16 @@ bool CTemplateExchange::GetSignDestination(const CTransaction& tx, const std::ve
     uint256 hashFork;
     int height;
     xengine::CIDataStream ds(vchSig);
-    ds >> vsm >> vss >> hashFork >> height;
+    try
+    {
+        ds >> vsm >> vss >> hashFork >> height;
+    }
+    catch(const std::exception& e)
+    {
+        StdError(__PRETTY_FUNCTION__, e.what());
+        return false;
+    }
+
     setSubDest.clear();
     if (!destSpend_m.IsPubKey() || !destSpend_s.IsPubKey())
     {
@@ -222,7 +231,15 @@ bool CTemplateExchange::BuildTxSignature(const uint256& hash,
     uint256 hashFork;
     int height;
     xengine::CIDataStream ds(vchSig);
-    ds >> vsm >> vss >> hashFork >> height;
+    try
+    {
+        ds >> vsm >> vss >> hashFork >> height;
+    }
+    catch(const std::exception& e)
+    {
+        StdError(__PRETTY_FUNCTION__, e.what());
+        return false;
+    }
 
     vchSig = vchData;
     std::vector<uint8_t> temp;
@@ -240,7 +257,16 @@ bool CTemplateExchange::VerifySignature(const uint256& hash, const std::vector<u
     std::vector<unsigned char> sign_m;
     std::vector<unsigned char> sign_s;
     std::vector<unsigned char> vchSig_;
-    is >> sign_m >> sign_s >> vchSig_;
+    try
+    {
+        is >> sign_m >> sign_s >> vchSig_;
+    }
+    catch(const std::exception& e)
+    {
+        StdError(__PRETTY_FUNCTION__, e.what());
+        return false;
+    }
+
     if (fork == fork_m)
     {
         if (height > height_m)

--- a/src/common/template/exchange.h
+++ b/src/common/template/exchange.h
@@ -26,6 +26,7 @@ public:
         const uint256& fork_m_,
         const uint256& fork_s_);
 
+    // TODO: should remove this because of no way to catch exception by xengine::CIDataStream::operator>>() in constructor
     CTemplateExchange(const std::vector<unsigned char>& vchDataIn);
     CTemplateExchange(const CDestination& destSpend_m_ = CDestination(),
                       const CDestination& destSpend_s_ = CDestination(),

--- a/src/crypto/key.cpp
+++ b/src/crypto/key.cpp
@@ -128,9 +128,17 @@ bool CKey::Load(const std::vector<unsigned char>& vchKey)
     uint32 check;
 
     xengine::CIDataStream is(vchKey);
-    is >> pubkey >> version;
-    is.Pop(cipherNew.encrypted, 48);
-    is >> cipherNew.nonce >> check;
+    try
+    {
+        is >> pubkey >> version;
+        is.Pop(cipherNew.encrypted, 48);
+        is >> cipherNew.nonce >> check;
+    }
+    catch(const std::exception& e)
+    {
+        StdError(__PRETTY_FUNCTION__, e.what());
+        return false;
+    }
 
     if (CryptoHash(&vchKey[0], vchKey.size() - 4).Get32() != check)
     {


### PR DESCRIPTION
```
Hi, please verify carefully, it works without AddressSanitizer(tested on binary release and self build without any pass custom compiler flags) and multiple OS my machine(Ubuntu and Arch Linux).
CStream::Serialize function in src/xengine/stream/stream.h doesn't check size input will be overflow and makes memory during Serialization goes high, resulting Out-Of-Memory(process killed by OS)/Denial of Service or degradation performance(consensus unusable)
```