### PR TITLE
Multiple signature: drop unsafe algorithm, and now signature form is (index, Ri, Si, ..., Rj, Sj)

### DIFF
--- a/src/bigbang/core.cpp
+++ b/src/bigbang/core.cpp
@@ -482,7 +482,7 @@ Errno CCoreProtocol::VerifyBlockTx(const CTransaction& tx, const CTxContxt& txCo
     {
         vchSig = tx.vchSig;
     }
-    if (!destIn.VerifyTxSignature(tx.GetSignatureHash(), tx.hashAnchor, tx.sendTo, vchSig, nForkHeight, fork))
+    if (!destIn.VerifyTxSignature(tx.GetSignatureHash(), tx.hashAnchor, tx.sendTo, vchSig, nForkHeight, fork, nForkHeight))
     {
         return DEBUG(ERR_TRANSACTION_SIGNATURE_INVALID, "invalid signature\n");
     }
@@ -539,7 +539,7 @@ Errno CCoreProtocol::VerifyTransaction(const CTransaction& tx, const vector<CTxO
         vchSig = tx.vchSig;
     }
 
-    if (!destIn.VerifyTxSignature(tx.GetSignatureHash(), tx.hashAnchor, tx.sendTo, vchSig, nForkHeight, fork))
+    if (!destIn.VerifyTxSignature(tx.GetSignatureHash(), tx.hashAnchor, tx.sendTo, vchSig, nForkHeight, fork, -1))
     {
         return DEBUG(ERR_TRANSACTION_SIGNATURE_INVALID, "invalid signature\n");
     }

--- a/src/bigbang/entry.cpp
+++ b/src/bigbang/entry.cpp
@@ -25,6 +25,7 @@
 #include "txpool.h"
 #include "version.h"
 #include "wallet.h"
+#include "template/template.h"
 
 #ifdef WIN32
 #ifdef _MSC_VER
@@ -164,6 +165,17 @@ bool CBbEntry::Initialize(int argc, char* argv[])
         return false;
     }
     StdLog("BigbangStartup", "Initialize: bigbang version is v%s, git commit id: %s", VERSION_STR.c_str(), GetGitVersion());
+
+    // template
+    if (config.GetConfig()->fTestNet)
+    {
+        MULTISIGN_HEIGHT = MULTISIGN_HEIGHT_TESTNET;
+    }
+    else
+    {
+        MULTISIGN_HEIGHT = MULTISIGN_HEIGHT_MAINNET;
+    }
+
     // modules
     return InitializeModules(config.GetModeType());
 }

--- a/src/bigbang/wallet.cpp
+++ b/src/bigbang/wallet.cpp
@@ -1411,7 +1411,7 @@ bool CWallet::SignPubKey(const crypto::CPubKey& pubkey, const uint256& hash, vec
     return true;
 }
 
-bool CWallet::SignMultiPubKey(const set<crypto::CPubKey>& setPubKey, const uint256& seed, const uint256& hash, vector<uint8>& vchSig)
+bool CWallet::SignMultiPubKey(const set<crypto::CPubKey>& setPubKey, const uint256& hash, vector<uint8>& vchSig)
 {
     bool fSigned = false;
     for (auto& pubkey : setPubKey)
@@ -1419,7 +1419,7 @@ bool CWallet::SignMultiPubKey(const set<crypto::CPubKey>& setPubKey, const uint2
         map<crypto::CPubKey, CWalletKeyStore>::iterator it = mapKeyStore.find(pubkey);
         if (it != mapKeyStore.end() && it->second.key.IsPrivKey())
         {
-            fSigned |= it->second.key.MultiSign(setPubKey, seed, hash, vchSig);
+            fSigned |= it->second.key.MultiSign(setPubKey, hash, vchSig);
             UpdateAutoLock(it->second);
         }
     }
@@ -1481,7 +1481,7 @@ bool CWallet::SignDestination(const CDestination& destIn, const CTransaction& tx
                 setPubKey.insert(dest.GetPubKey());
             }
 
-            if (!SignMultiPubKey(setPubKey, tx.hashAnchor, hash, vchSubSig))
+            if (!SignMultiPubKey(setPubKey, hash, vchSubSig))
             {
                 StdError("CWallet", "SignDestination: SignMultiPubKey fail, txid: %s", tx.GetHash().GetHex().c_str());
                 return false;

--- a/src/bigbang/wallet.h
+++ b/src/bigbang/wallet.h
@@ -208,7 +208,7 @@ protected:
     std::shared_ptr<CWalletTx> LoadWalletTx(const uint256& txid);
     std::shared_ptr<CWalletTx> InsertWalletTx(const uint256& txid, const CAssembledTx& tx, const uint256& hashFork, bool fIsMine, bool fFromMe);
     bool SignPubKey(const crypto::CPubKey& pubkey, const uint256& hash, std::vector<uint8>& vchSig);
-    bool SignMultiPubKey(const std::set<crypto::CPubKey>& setPubKey, const uint256& seed, const uint256& hash, std::vector<uint8>& vchSig);
+    bool SignMultiPubKey(const std::set<crypto::CPubKey>& setPubKey, const uint256& hash, std::vector<uint8>& vchSig);
     bool SignDestination(const CDestination& destIn, const CTransaction& tx, const uint256& hash, std::vector<uint8>& vchSig, bool& fCompleted);
     void UpdateAutoLock(CWalletKeyStore& keystore);
     bool UpdateFork();

--- a/src/common/destination.cpp
+++ b/src/common/destination.cpp
@@ -157,12 +157,12 @@ bool CDestination::VerifyTxSignature(const uint256& hash, const uint256& hashAnc
 }
 
 bool CDestination::VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                     const std::vector<uint8>& vchSig, const int32 nHeight, const uint256& fork) const
+                                     const std::vector<uint8>& vchSig, const int32 nForkHeight, const uint256& fork, const int32 nHeight) const
 {
     // if (IsTemplate() && GetTemplateId().GetType() == TEMPLATE_EXCHANGE)
     // {
     //     std::shared_ptr<CTemplateExchange> sp = std::make_shared<CTemplateExchange>(vchSig);
-    //     return sp->VerifySignature(hash, vchSig, nHeight, fork);
+    //     return sp->VerifySignature(hash, vchSig, nForkHeight, fork);
     // }
     // else
     {

--- a/src/common/destination.cpp
+++ b/src/common/destination.cpp
@@ -142,7 +142,7 @@ const CTemplateId CDestination::GetTemplateId() const
 }
 
 bool CDestination::VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                     const std::vector<uint8>& vchSig, bool& fCompleted) const
+                                     const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const
 {
     if (IsPubKey())
     {
@@ -151,23 +151,23 @@ bool CDestination::VerifyTxSignature(const uint256& hash, const uint256& hashAnc
     }
     else if (IsTemplate())
     {
-        return CTemplate::VerifyTxSignature(GetTemplateId(), hash, hashAnchor, destTo, vchSig, fCompleted);
+        return CTemplate::VerifyTxSignature(GetTemplateId(), hash, hashAnchor, destTo, vchSig, nHeight, fCompleted);
     }
     return false;
 }
 
 bool CDestination::VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                     const std::vector<uint8>& vchSig, int nForkHeight, const uint256& fork) const
+                                     const std::vector<uint8>& vchSig, const int32 nHeight, const uint256& fork) const
 {
     // if (IsTemplate() && GetTemplateId().GetType() == TEMPLATE_EXCHANGE)
     // {
     //     std::shared_ptr<CTemplateExchange> sp = std::make_shared<CTemplateExchange>(vchSig);
-    //     return sp->VerifySignature(hash, vchSig, nForkHeight, fork);
+    //     return sp->VerifySignature(hash, vchSig, nHeight, fork);
     // }
     // else
     {
         bool fCompleted = false;
-        return VerifyTxSignature(hash, hashAnchor, destTo, vchSig, fCompleted) && fCompleted;
+        return VerifyTxSignature(hash, hashAnchor, destTo, vchSig, nHeight, fCompleted) && fCompleted;
     }
 }
 

--- a/src/common/destination.h
+++ b/src/common/destination.h
@@ -63,9 +63,9 @@ public:
     const CTemplateId GetTemplateId() const;
 
     bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                           const std::vector<uint8>& vchSig, bool& fCompleted) const;
+                           const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const;
     bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                           const std::vector<uint8>& vchSig, int nForkHeight, const uint256& fork) const;
+                           const std::vector<uint8>& vchSig, const int32 nHeight, const uint256& fork) const;
 
     bool VerifyBlockSignature(const uint256& hash, const std::vector<uint8>& vchSig) const;
 

--- a/src/common/destination.h
+++ b/src/common/destination.h
@@ -65,7 +65,7 @@ public:
     bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
                            const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const;
     bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                           const std::vector<uint8>& vchSig, const int32 nHeight, const uint256& fork) const;
+                           const std::vector<uint8>& vchSig, const int32 nForkHeight, const uint256& fork, const int32 nHeight) const;
 
     bool VerifyBlockSignature(const uint256& hash, const std::vector<uint8>& vchSig) const;
 

--- a/src/common/template/delegate.cpp
+++ b/src/common/template/delegate.cpp
@@ -133,15 +133,15 @@ void CTemplateDelegate::BuildTemplateData()
 }
 
 bool CTemplateDelegate::VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                          const vector<uint8>& vchSig, bool& fCompleted) const
+                                          const vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const
 {
     if (destTo.GetTemplateId() == nId)
     {
-        return CDestination(keyDelegate).VerifyTxSignature(hash, hashAnchor, destTo, vchSig, fCompleted);
+        return CDestination(keyDelegate).VerifyTxSignature(hash, hashAnchor, destTo, vchSig, nHeight, fCompleted);
     }
     else
     {
-        return destTo.VerifyTxSignature(hash, hashAnchor, destTo, vchSig, fCompleted);
+        return destTo.VerifyTxSignature(hash, hashAnchor, destTo, vchSig, nHeight, fCompleted);
     }
 }
 

--- a/src/common/template/delegate.h
+++ b/src/common/template/delegate.h
@@ -26,7 +26,7 @@ protected:
     virtual bool SetTemplateData(const bigbang::rpc::CTemplateRequest& obj, CDestination&& destInstance);
     virtual void BuildTemplateData();
     virtual bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                   const std::vector<uint8>& vchSig, bool& fCompleted) const;
+                                   const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const;
     virtual bool VerifyBlockSignature(const uint256& hash, const std::vector<uint8>& vchSig) const;
 
 protected:

--- a/src/common/template/exchange.cpp
+++ b/src/common/template/exchange.cpp
@@ -164,7 +164,7 @@ void CTemplateExchange::BuildTemplateData()
 }
 
 bool CTemplateExchange::VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                          const vector<uint8>& vchSig, bool& fCompleted) const
+                                          const vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const
 {
     return true;
 }

--- a/src/common/template/exchange.h
+++ b/src/common/template/exchange.h
@@ -55,7 +55,7 @@ protected:
     virtual void BuildTemplateData();
 
     virtual bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                   const std::vector<uint8>& vchSig, bool& fCompleted) const;
+                                   const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const;
 
 public:
     CDestination destSpend_m;

--- a/src/common/template/fork.cpp
+++ b/src/common/template/fork.cpp
@@ -118,7 +118,7 @@ void CTemplateFork::BuildTemplateData()
 }
 
 bool CTemplateFork::VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                      const vector<uint8>& vchSig, bool& fCompleted) const
+                                      const vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const
 {
-    return destRedeem.VerifyTxSignature(hash, hashAnchor, destTo, vchSig, fCompleted);
+    return destRedeem.VerifyTxSignature(hash, hashAnchor, destTo, vchSig, nHeight, fCompleted);
 }

--- a/src/common/template/fork.h
+++ b/src/common/template/fork.h
@@ -26,7 +26,7 @@ protected:
     virtual bool SetTemplateData(const bigbang::rpc::CTemplateRequest& obj, CDestination&& destInstance);
     virtual void BuildTemplateData();
     virtual bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                   const std::vector<uint8>& vchSig, bool& fCompleted) const;
+                                   const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const;
 
 protected:
     CDestination destRedeem;

--- a/src/common/template/proof.cpp
+++ b/src/common/template/proof.cpp
@@ -106,9 +106,9 @@ void CTemplateProof::BuildTemplateData()
 }
 
 bool CTemplateProof::VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                       const vector<uint8>& vchSig, bool& fCompleted) const
+                                       const vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const
 {
-    return destSpend.VerifyTxSignature(hash, hashAnchor, destTo, vchSig, fCompleted);
+    return destSpend.VerifyTxSignature(hash, hashAnchor, destTo, vchSig, nHeight, fCompleted);
 }
 
 bool CTemplateProof::VerifyBlockSignature(const uint256& hash, const vector<uint8>& vchSig) const

--- a/src/common/template/proof.h
+++ b/src/common/template/proof.h
@@ -24,7 +24,7 @@ protected:
     virtual bool SetTemplateData(const bigbang::rpc::CTemplateRequest& obj, CDestination&& destInstance);
     virtual void BuildTemplateData();
     virtual bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                   const std::vector<uint8>& vchSig, bool& fCompleted) const;
+                                   const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const;
     virtual bool VerifyBlockSignature(const uint256& hash, const std::vector<uint8>& vchSig) const;
 
 protected:

--- a/src/common/template/template.cpp
+++ b/src/common/template/template.cpp
@@ -158,7 +158,7 @@ string CTemplate::GetTypeName(uint16 nTypeIn)
 }
 
 bool CTemplate::VerifyTxSignature(const CTemplateId& nIdIn, const uint256& hash, const uint256& hashAnchor,
-                                  const CDestination& destTo, const vector<uint8>& vchSig, bool& fCompleted)
+                                  const CDestination& destTo, const vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted)
 {
     CTemplatePtr ptr = CreateTemplatePtr(nIdIn.GetType(), vchSig);
     if (!ptr)
@@ -172,7 +172,7 @@ bool CTemplate::VerifyTxSignature(const CTemplateId& nIdIn, const uint256& hash,
     }
 
     vector<uint8> vchSubSig(vchSig.begin() + ptr->vchData.size(), vchSig.end());
-    return ptr->VerifyTxSignature(hash, hashAnchor, destTo, vchSubSig, fCompleted);
+    return ptr->VerifyTxSignature(hash, hashAnchor, destTo, vchSubSig, nHeight, fCompleted);
 }
 
 bool CTemplate::IsTxSpendable(const CDestination& dest)
@@ -269,7 +269,7 @@ bool CTemplate::BuildTxSignature(const uint256& hash, const uint256& hashAnchor,
                                  const vector<uint8>& vchPreSig, vector<uint8>& vchSig, bool& fCompleted) const
 {
     vchSig = vchData;
-    if (!VerifyTxSignature(hash, hashAnchor, destTo, vchPreSig, fCompleted))
+    if (!VerifyTxSignature(hash, hashAnchor, destTo, vchPreSig, -1, fCompleted))
     {
         return false;
     }

--- a/src/common/template/template.cpp
+++ b/src/common/template/template.cpp
@@ -26,6 +26,8 @@ using namespace xengine;
 using namespace bigbang::crypto;
 using namespace bigbang::rpc;
 
+int32 MULTISIGN_HEIGHT = MULTISIGN_HEIGHT_MAINNET;
+
 struct CTypeInfo
 {
     uint16 nType;

--- a/src/common/template/template.h
+++ b/src/common/template/template.h
@@ -114,7 +114,7 @@ public:
 
     // Verify transaction signature.
     static bool VerifyTxSignature(const CTemplateId& nIdIn, const uint256& hash, const uint256& hashAnchor,
-                                  const CDestination& destTo, const std::vector<uint8>& vchSig, bool& fCompleted);
+                                  const CDestination& destTo, const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted);
 
     // Return dest is spendable or not.
     static bool IsTxSpendable(const CDestination& dest);
@@ -187,7 +187,7 @@ protected:
 
     // Verify transaction signature by concrete template.
     virtual bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                   const std::vector<uint8>& vchSig, bool& fCompleted) const = 0;
+                                   const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const = 0;
 
 protected:
     uint16 nType;

--- a/src/common/template/template.h
+++ b/src/common/template/template.h
@@ -16,6 +16,10 @@
 #include "templateid.h"
 #include "util.h"
 
+const int32 MULTISIGN_HEIGHT_MAINNET = 72000;
+const int32 MULTISIGN_HEIGHT_TESTNET = 0;
+extern int32 MULTISIGN_HEIGHT;
+
 class CSpendableTemplate
 {
 };

--- a/src/common/template/weighted.cpp
+++ b/src/common/template/weighted.cpp
@@ -147,7 +147,7 @@ bool CTemplateWeighted::VerifyTxSignature(const uint256& hash, const uint256& ha
 
     set<uint256> setPartKey;
     // before 72000, used defect multi-sign alogrithm
-    if (nHeight > 0 && nHeight < 72000)
+    if (nHeight >= 0 && nHeight < MULTISIGN_HEIGHT)
     {
         if (!CryptoMultiVerifyDefect(setPubKey, hashAnchor.begin(), hashAnchor.size(), hash.begin(), hash.size(), vchSig, setPartKey))
         {

--- a/src/common/template/weighted.cpp
+++ b/src/common/template/weighted.cpp
@@ -137,7 +137,7 @@ void CTemplateWeighted::BuildTemplateData()
 }
 
 bool CTemplateWeighted::VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                          const vector<uint8>& vchSig, bool& fCompleted) const
+                                          const vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const
 {
     set<uint256> setPubKey;
     for (const auto& keyweight : mapPubKeyWeight)
@@ -146,9 +146,20 @@ bool CTemplateWeighted::VerifyTxSignature(const uint256& hash, const uint256& ha
     }
 
     set<uint256> setPartKey;
-    if (!CryptoMultiVerify(setPubKey, hash.begin(), hash.size(), vchSig, setPartKey))
+    // before 72000, used defect multi-sign alogrithm
+    if (nHeight > 0 && nHeight < 72000)
     {
-        return false;
+        if (!CryptoMultiVerifyDefect(setPubKey, hashAnchor.begin(), hashAnchor.size(), hash.begin(), hash.size(), vchSig, setPartKey))
+        {
+            return false;
+        }
+    }
+    else
+    {
+        if (!CryptoMultiVerify(setPubKey, hash.begin(), hash.size(), vchSig, setPartKey))
+        {
+            return false;
+        }
     }
 
     int nWeight = 0;

--- a/src/common/template/weighted.cpp
+++ b/src/common/template/weighted.cpp
@@ -146,8 +146,7 @@ bool CTemplateWeighted::VerifyTxSignature(const uint256& hash, const uint256& ha
     }
 
     set<uint256> setPartKey;
-    if (!CryptoMultiVerify(setPubKey, hashAnchor.begin(), hashAnchor.size(),
-                           hash.begin(), hash.size(), vchSig, setPartKey))
+    if (!CryptoMultiVerify(setPubKey, hash.begin(), hash.size(), vchSig, setPartKey))
     {
         return false;
     }

--- a/src/common/template/weighted.h
+++ b/src/common/template/weighted.h
@@ -23,7 +23,7 @@ protected:
     virtual bool SetTemplateData(const bigbang::rpc::CTemplateRequest& obj, CDestination&& destInstance);
     virtual void BuildTemplateData();
     virtual bool VerifyTxSignature(const uint256& hash, const uint256& hashAnchor, const CDestination& destTo,
-                                   const std::vector<uint8>& vchSig, bool& fCompleted) const;
+                                   const std::vector<uint8>& vchSig, const int32 nHeight, bool& fCompleted) const;
 
 protected:
     uint8 nRequired;

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -126,6 +126,9 @@ bool CryptoVerify(const uint256& pubkey, const void* md, const std::size_t len, 
 //   Si = Ri + hash(Ri,Pi,M) * Pi
 bool CryptoMultiSign(const std::set<uint256>& setPubKey, const CCryptoKey& privkey, const uint8* pM, const std::size_t lenM, std::vector<uint8>& vchSig);
 bool CryptoMultiVerify(const std::set<uint256>& setPubKey, const uint8* pM, const std::size_t lenM, const std::vector<uint8>& vchSig, std::set<uint256>& setPartKey);
+// defect old version multi-sign algorithm, only for backward compatiblility. 
+bool CryptoMultiVerifyDefect(const std::set<uint256>& setPubKey, const uint8* pX, const size_t lenX,
+                       const uint8* pM, const size_t lenM, const std::vector<uint8>& vchSig, std::set<uint256>& setPartKey);
 
 // Encrypt
 struct CCryptoCipher

--- a/src/crypto/curve25519/sc25519.cpp
+++ b/src/crypto/curve25519/sc25519.cpp
@@ -14,6 +14,25 @@ namespace curve25519
 // 2^252 + 27742317777372353535851937790883648493
 const uint64_t CSC25519::prime[4] = { 0x5812631a5cf5d3ed, 0x14def9dea2f79cd6, 0, 0x1000000000000000 };
 
+CSC25519 CSC25519::Reduce64(uint8_t m[64])
+{
+    CSC25519 sc;
+    // BarrettReduce deals range [0, 2^506]. If m > 2^506, reduce the highest 256 bits first.
+    if (m[63] & 0xFC)
+    {
+        uint8_t n[64];
+        sc.Unpack(m + 32);
+        sc.Pack(n + 32);
+        memmove(n, m, 32);
+        sc.BarrettReduce((uint64_t*)n);
+    }
+    else
+    {
+        sc.BarrettReduce((uint64_t*)m);
+    }
+    return sc;
+}
+
 CSC25519::CSC25519()
 {
     Zero32(value);
@@ -334,8 +353,7 @@ void CSC25519::BarrettReduce(uint64_t* m)
 
     Sub32(value, r1, r2);
 
-    Reduce();
-    Reduce();
+    Reduce(0);
 }
 
 const CSC25519 CSC25519::naturalPowTable[51][26] = {

--- a/src/crypto/curve25519/sc25519.h
+++ b/src/crypto/curve25519/sc25519.h
@@ -16,6 +16,8 @@ class CSC25519
 public:
     static const CSC25519 naturalPowTable[51][26];
 
+    static CSC25519 Reduce64(uint8_t m[64]);
+
 public:
     CSC25519();
     CSC25519(const CSC25519& sc);

--- a/src/crypto/key.cpp
+++ b/src/crypto/key.cpp
@@ -30,12 +30,6 @@ bool CPubKey::Verify(const uint256& hash, const std::vector<uint8>& vchSig) cons
     return CryptoVerify(*this, &hash, sizeof(hash), vchSig);
 }
 
-bool CPubKey::MultiVerify(const std::set<uint256>& setPubKey, const uint256& hash, const std::vector<uint8>& vchSig)
-{
-    std::set<uint256> setPartKey;
-    return CryptoMultiVerify(setPubKey, hash.begin(), hash.size(), vchSig, setPartKey);
-}
-
 //////////////////////////////
 // CKey
 

--- a/src/crypto/key.cpp
+++ b/src/crypto/key.cpp
@@ -30,11 +30,10 @@ bool CPubKey::Verify(const uint256& hash, const std::vector<uint8>& vchSig) cons
     return CryptoVerify(*this, &hash, sizeof(hash), vchSig);
 }
 
-bool CPubKey::MultiVerify(const std::set<uint256>& setPubKey, const uint256& seed,
-                          const uint256& hash, const std::vector<uint8>& vchSig)
+bool CPubKey::MultiVerify(const std::set<uint256>& setPubKey, const uint256& hash, const std::vector<uint8>& vchSig)
 {
     std::set<uint256> setPartKey;
-    return CryptoMultiVerify(setPubKey, seed.begin(), seed.size(), hash.begin(), hash.size(), vchSig, setPartKey);
+    return CryptoMultiVerify(setPubKey, hash.begin(), hash.size(), vchSig, setPartKey);
 }
 
 //////////////////////////////
@@ -134,7 +133,7 @@ bool CKey::Load(const std::vector<unsigned char>& vchKey)
         is.Pop(cipherNew.encrypted, 48);
         is >> cipherNew.nonce >> check;
     }
-    catch(const std::exception& e)
+    catch (const std::exception& e)
     {
         StdError(__PRETTY_FUNCTION__, e.what());
         return false;
@@ -215,13 +214,11 @@ bool CKey::Sign(const uint256& hash, std::vector<uint8>& vchSig) const
     return true;
 }
 
-bool CKey::MultiSign(const std::set<CPubKey>& setPubKey, const uint256& seed,
-                     const uint256& hash, std::vector<uint8>& vchSig) const
+bool CKey::MultiSign(const std::set<CPubKey>& setPubKey, const uint256& hash, std::vector<uint8>& vchSig) const
 {
     if (!IsNull() && !IsLocked())
     {
-        CryptoMultiSign(std::set<uint256>(setPubKey.begin(), setPubKey.end()), *pCryptoKey,
-                        seed.begin(), seed.size(), hash.begin(), hash.size(), vchSig);
+        CryptoMultiSign(std::set<uint256>(setPubKey.begin(), setPubKey.end()), *pCryptoKey, hash.begin(), hash.size(), vchSig);
         return true;
     }
     return false;

--- a/src/crypto/key.h
+++ b/src/crypto/key.h
@@ -18,8 +18,7 @@ public:
     CPubKey();
     CPubKey(const uint256& pubkey);
     bool Verify(const uint256& hash, const std::vector<uint8>& vchSig) const;
-    static bool MultiVerify(const std::set<uint256>& setPubKey, const uint256& seed,
-                            const uint256& hash, const std::vector<uint8>& vchSig);
+    static bool MultiVerify(const std::set<uint256>& setPubKey, const uint256& hash, const std::vector<uint8>& vchSig);
 };
 
 class CKey
@@ -52,8 +51,7 @@ public:
     const CPubKey GetPubKey() const;
     const CCryptoCipher& GetCipher() const;
     bool Sign(const uint256& hash, std::vector<uint8>& vchSig) const;
-    bool MultiSign(const std::set<CPubKey>& setPubKey, const uint256& seed,
-                   const uint256& hash, std::vector<uint8>& vchSig) const;
+    bool MultiSign(const std::set<CPubKey>& setPubKey, const uint256& hash, std::vector<uint8>& vchSig) const;
     bool Encrypt(const CCryptoString& strPassphrase,
                  const CCryptoString& strCurrentPassphrase = "");
     void Lock();

--- a/src/crypto/key.h
+++ b/src/crypto/key.h
@@ -18,7 +18,6 @@ public:
     CPubKey();
     CPubKey(const uint256& pubkey);
     bool Verify(const uint256& hash, const std::vector<uint8>& vchSig) const;
-    static bool MultiVerify(const std::set<uint256>& setPubKey, const uint256& hash, const std::vector<uint8>& vchSig);
 };
 
 class CKey

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(test_big
     OpenSSL::Crypto
     # mpvss
     crypto
+    xengine
 )
 
 add_executable(test_ctsdb test_big_main.cpp test_big.h test_big.cpp ctsdb_test.cpp)

--- a/test/crypto_tests.cpp
+++ b/test/crypto_tests.cpp
@@ -16,15 +16,12 @@ BOOST_AUTO_TEST_CASE(multisign)
 {
     srand(time(0));
 
-    int64_t keyCount = 0;
     int64_t signCount = 0, signTime = 0, verifyTime = 0;
     int count = 100;
     for (int i = 0; i < count; i++)
     {
-        uint32_t nKey = CryptoGetRand32() % 16 + 1;
+        uint32_t nKey = CryptoGetRand32() % 256 + 1;
         uint32_t nPartKey = CryptoGetRand32() % nKey + 1;
-
-        keyCount += nKey;
 
         CCryptoKey* keys = new CCryptoKey[nKey];
         std::set<uint256> setPubKey;
@@ -34,8 +31,6 @@ BOOST_AUTO_TEST_CASE(multisign)
             setPubKey.insert(keys[i].pubkey);
         }
 
-        uint256 anchor;
-        CryptoGetRand256(anchor);
         uint256 msg;
         CryptoGetRand256(msg);
 
@@ -43,23 +38,22 @@ BOOST_AUTO_TEST_CASE(multisign)
         for (int i = 0; i < nPartKey; i++)
         {
             boost::posix_time::ptime t0 = boost::posix_time::microsec_clock::universal_time();
-            BOOST_CHECK(CryptoMultiSign(setPubKey, keys[i], anchor.begin(), anchor.size(), msg.begin(), msg.size(), vchSig));
+            BOOST_CHECK(CryptoMultiSign(setPubKey, keys[i], msg.begin(), msg.size(), vchSig));
             boost::posix_time::ptime t1 = boost::posix_time::microsec_clock::universal_time();
-            signTime = (t1 - t0).ticks();
+            signTime += (t1 - t0).ticks();
             ++signCount;
         }
 
         std::set<uint256> setPartKey;
         boost::posix_time::ptime t0 = boost::posix_time::microsec_clock::universal_time();
-        BOOST_CHECK(CryptoMultiVerify(setPubKey, anchor.begin(), anchor.size(), msg.begin(), msg.size(), vchSig, setPartKey) && (setPartKey.size() == nPartKey));
+        BOOST_CHECK(CryptoMultiVerify(setPubKey, msg.begin(), msg.size(), vchSig, setPartKey) && (setPartKey.size() == nPartKey));
         boost::posix_time::ptime t1 = boost::posix_time::microsec_clock::universal_time();
         verifyTime += (t1 - t0).ticks();
     }
 
-    std::cout << "multisign key count : " << keyCount << std::endl;
+    std::cout << "multisign count : " << count << std::endl;
     std::cout << "multisign sign count : " << signCount << "; average time : " << signTime / signCount << "us." << std::endl;
-    std::cout << "multisign verify count : " << count << "; time per count : " << verifyTime / count << "us."
-              << " time per key count: " << verifyTime / keyCount << "us." << std::endl;
+    std::cout << "multisign verify count : " << count << "; time per count : " << verifyTime / count << "us.; time per key: " << verifyTime / signCount << "us." << std::endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
 - the signature form is `(index, Ri, Si, ..., Rj, Sj) `
 - the `index` is a bitmap, store the index of signed keys.
 - `(Ri, Si)` is the same as the common signature

Detail see [Multisignature](https://github.com/bigbangcore/BigBang/wiki/Multisignature) or [多重签名](https://github.com/bigbangcore/BigBang/wiki/%E5%A4%9A%E9%87%8D%E7%AD%BE%E5%90%8D)