### PR TITLE
modify pow 60s time

### DIFF
--- a/src/bigbang/core.cpp
+++ b/src/bigbang/core.cpp
@@ -47,6 +47,7 @@ static const uint32 DELEGATE_PROOF_OF_STAKE_ENROLL_TRUST_HEIGHT = 1;
 static const uint32 DELEGATE_PROOF_OF_STAKE_NETCACHE_HEIGHT = 1;
 static const uint32 DELEGATE_PROOF_OF_STAKE_DPOSTIME_HEIGHT = 1;
 static const uint32 DELEGATE_PROOF_OF_STAKE_POWTIME_HEIGHT = 1;
+static const uint32 DELEGATE_PROOF_OF_STAKE_DPOS_60TIME_HEIGHT = 1;
 
 #ifndef BBCP_SET_TOKEN_DISTRIBUTION
 static const int64 BBCP_TOKEN_INIT = 300000000;
@@ -1018,10 +1019,22 @@ uint32 CCoreProtocol::GetNextBlockTimeStamp(uint16 nPrevMintType, uint32 nPrevTi
         }
         return nPrevTimeStamp + BLOCK_TARGET_SPACING;
     }
-    else
+    if (nTargetHeight < DELEGATE_PROOF_OF_STAKE_DPOS_60TIME_HEIGHT)
     {
         if (nTargetMintType == CTransaction::TX_WORK)
         {
+            return nPrevTimeStamp + PROOF_OF_WORK_BLOCK_SPACING;
+        }
+        return nPrevTimeStamp + BLOCK_TARGET_SPACING;
+    }
+    else
+    {
+        if (nPrevMintType == CTransaction::TX_WORK || nPrevMintType == CTransaction::TX_GENESIS)
+        {
+            if (nTargetMintType == CTransaction::TX_STAKE)
+            {
+                return nPrevTimeStamp + BLOCK_TARGET_SPACING;
+            }
             return nPrevTimeStamp + PROOF_OF_WORK_BLOCK_SPACING;
         }
         return nPrevTimeStamp + BLOCK_TARGET_SPACING;


### PR DESCRIPTION
如果POW块的前一块为DPOS块，则本POW的时间戳应大于等于前一块时间戳+60，否则会出现子链上POW对应的空块时间戳小于前一高度的子块时间戳，这个原FNFN也存在该问题。
测试发现子链交易会出现缺少前序的问题。