### PR TITLE
Fix issue 493

### DIFF
--- a/src/bigbang/blockchain.cpp
+++ b/src/bigbang/blockchain.cpp
@@ -494,6 +494,7 @@ Errno CBlockChain::AddNewBlock(const CBlock& block, CBlockChainUpdate& update)
 
         nTotalFee += tx.nTxFee;
     }
+    view.AddBlock(hash, blockex);
 
     if (block.txMint.nAmount > nTotalFee + nReward)
     {
@@ -538,11 +539,7 @@ Errno CBlockChain::AddNewBlock(const CBlock& block, CBlockChainUpdate& update)
 
     update = CBlockChainUpdate(pIndexNew);
     view.GetTxUpdated(update.setTxUpdate);
-    if (!GetBlockChanges(pIndexNew, pIndexFork, update.vBlockAddNew, update.vBlockRemove))
-    {
-        Log("AddNewBlock Storage GetBlockChanges Error : %s ", hash.ToString().c_str());
-        return ERR_SYS_STORAGE_ERROR;
-    }
+    view.GetBlockChanges(update.vBlockAddNew, update.vBlockRemove);
 
     if (!update.vBlockRemove.empty())
     {

--- a/src/bigbang/txpool.cpp
+++ b/src/bigbang/txpool.cpp
@@ -209,36 +209,37 @@ void CTxPoolView::InvalidateSpent(const CTxOutPoint& out, CTxPoolView& viewInvol
     for (std::size_t i = 0; i < vOutPoint.size(); i++)
     {
         uint256 txidNextTx;
-        if (GetSpent(vOutPoint[i], txidNextTx))
+        CPooledTx* pNextTx = nullptr;
+        if (GetSpent(vOutPoint[i], txidNextTx) && ((pNextTx = Get(txidNextTx)) != nullptr))
         {
-            CPooledTx* pNextTx = nullptr;
-            if ((pNextTx = Get(txidNextTx)) != nullptr)
+            for (const CTxIn& txin : pNextTx->vInput)
             {
-                for (const CTxIn& txin : pNextTx->vInput)
-                {
-                    SetUnspent(txin.prevout);
-                }
-                CTxOutPoint out0(txidNextTx, 0);
-                if (IsSpent(out0))
-                {
-                    vOutPoint.push_back(out0);
-                }
-                else
-                {
-                    mapSpent.erase(out0);
-                }
-                CTxOutPoint out1(txidNextTx, 1);
-                if (IsSpent(out1))
-                {
-                    vOutPoint.push_back(out1);
-                }
-                else
-                {
-                    mapSpent.erase(out1);
-                }
-                viewInvolvedTx.AddNew(txidNextTx, *pNextTx);
-                setTxLinkIndex.erase(txidNextTx);
+                SetUnspent(txin.prevout);
             }
+            CTxOutPoint out0(txidNextTx, 0);
+            if (IsSpent(out0))
+            {
+                vOutPoint.push_back(out0);
+            }
+            else
+            {
+                mapSpent.erase(out0);
+            }
+            CTxOutPoint out1(txidNextTx, 1);
+            if (IsSpent(out1))
+            {
+                vOutPoint.push_back(out1);
+            }
+            else
+            {
+                mapSpent.erase(out1);
+            }
+            viewInvolvedTx.AddNew(txidNextTx, *pNextTx);
+            setTxLinkIndex.erase(txidNextTx);
+        }
+        else
+        {
+            mapSpent.erase(vOutPoint[i]);
         }
     }
 }

--- a/src/storage/blockbase.cpp
+++ b/src/storage/blockbase.cpp
@@ -180,6 +180,16 @@ void CBlockView::RemoveTx(const uint256& txid, const CTransaction& tx, const CTx
     mapUnspent[CTxOutPoint(txid, 1)].Disable();
 }
 
+void CBlockView::AddBlock(const uint256& hash, const CBlockEx& block)
+{
+    InsertBlockList(hash, block, vBlockAddNew);
+}
+
+void CBlockView::RemoveBlock(const uint256& hash, const CBlockEx& block)
+{
+    InsertBlockList(hash, block, vBlockRemove);
+}
+
 void CBlockView::GetUnspentChanges(vector<CTxUnspent>& vAddNew, vector<CTxOutPoint>& vRemove)
 {
     vAddNew.reserve(mapUnspent.size());
@@ -227,6 +237,46 @@ void CBlockView::GetTxRemoved(vector<uint256>& vRemove)
         }
     }
 }
+
+void CBlockView::GetBlockChanges(vector<CBlockEx>& vAdd, vector<CBlockEx>& vRemove) const
+{
+    vAdd.clear();
+    vAdd.reserve(vBlockAddNew.size());
+    for (auto& pair : vBlockAddNew)
+    {
+        vAdd.push_back(pair.second);
+    }
+
+    vRemove.clear();
+    vRemove.reserve(vBlockRemove.size());
+    for (auto& pair : vBlockRemove)
+    {
+        vRemove.push_back(pair.second);
+    }
+}
+
+void CBlockView::InsertBlockList(const uint256& hash, const CBlockEx& block, list<pair<uint256, CBlockEx>>& blockList)
+{
+    // store reserve block order
+    auto pair = make_pair(hash, block);
+    if (blockList.empty())
+    {
+        blockList.push_back(pair);
+    }
+    else if (block.hashPrev == blockList.front().first)
+    {
+        blockList.push_front(pair);
+    }
+    else if (blockList.back().second.hashPrev == hash)
+    {
+        blockList.push_back(pair);
+    }
+    else
+    {
+        StdError("CBlockView", "InsertBlockList error, no prev and next of block: %s", hash.ToString().c_str());
+    }
+}
+
 
 //////////////////////////////
 // CForkHeightIndex
@@ -916,6 +966,7 @@ bool CBlockBase::GetBlockView(const uint256& hash, CBlockView& view, bool fCommi
                 view.RemoveTx(block.txMint.GetHash(), block.txMint);
                 ++nTxRemoved;
             }
+            view.RemoveBlock(p->GetBlockHash(), block);
         }
         if (nBlockRemoved > 0)
         {
@@ -954,6 +1005,7 @@ bool CBlockBase::GetBlockView(const uint256& hash, CBlockView& view, bool fCommi
                 view.AddTx(block.vtx[j].GetHash(), block.vtx[j], txContxt.destIn, txContxt.GetValueIn());
                 ++nTxAdded;
             }
+            view.AddBlock(vPath[i]->GetBlockHash(), block);
         }
         if (vPath.size() > 0)
         {

--- a/src/storage/blockbase.h
+++ b/src/storage/blockbase.h
@@ -7,6 +7,7 @@
 
 #include <boost/smart_ptr/shared_ptr.hpp>
 #include <boost/thread/thread.hpp>
+#include <list>
 #include <map>
 #include <numeric>
 
@@ -166,9 +167,15 @@ public:
         AddTx(txid, tx, tx.destIn, tx.nValueIn);
     }
     void RemoveTx(const uint256& txid, const CTransaction& tx, const CTxContxt& txContxt = CTxContxt());
+    void AddBlock(const uint256& hash, const CBlockEx& block);
+    void RemoveBlock(const uint256& hash, const CBlockEx& block);
     void GetUnspentChanges(std::vector<CTxUnspent>& vAddNew, std::vector<CTxOutPoint>& vRemove);
     void GetTxUpdated(std::set<uint256>& setUpdate);
     void GetTxRemoved(std::vector<uint256>& vRemove);
+    void GetBlockChanges(std::vector<CBlockEx>& vAdd, std::vector<CBlockEx>& vRemove) const;
+
+protected:
+    void InsertBlockList(const uint256& hash, const CBlockEx& block, std::list<std::pair<uint256, CBlockEx>>& blockList);
 
 protected:
     CBlockBase* pBlockBase;
@@ -179,6 +186,8 @@ protected:
     std::map<CTxOutPoint, CUnspent> mapUnspent;
     std::vector<uint256> vTxRemove;
     std::vector<uint256> vTxAddNew;
+    std::list<std::pair<uint256, CBlockEx>> vBlockAddNew;
+    std::list<std::pair<uint256, CBlockEx>> vBlockRemove;
 };
 
 class CBlockHeightIndex


### PR DESCRIPTION
 - Get block changes from CBlockView
 - In CTxPoolView::InvalidateSpent, remove the unspent UTXO

Fix problem 2 and 3 of issue #493 