### PR TITLE
add checkpoint to dpos

### DIFF
--- a/src/bigbang/base.h
+++ b/src/bigbang/base.h
@@ -65,6 +65,34 @@ public:
 class IBlockChain : public xengine::IBase
 {
 public:
+    class CCheckPoint
+    {
+    public:
+        CCheckPoint()
+          : nHeight(-1)
+        {
+        }
+        CCheckPoint(int nHeightIn, const uint256& nBlockHashIn)
+          : nHeight(nHeightIn), nBlockHash(nBlockHashIn)
+        {
+        }
+        CCheckPoint(const CCheckPoint& point)
+          : nHeight(point.nHeight), nBlockHash(point.nBlockHash)
+        {
+        }
+        CCheckPoint& operator=(const CCheckPoint& point)
+        {
+            nHeight = point.nHeight;
+            nBlockHash = point.nBlockHash;
+            return *this;
+        }
+
+    public:
+        int nHeight;
+        uint256 nBlockHash;
+    };
+
+public:
     IBlockChain()
       : IBase("blockchain") {}
     virtual void GetForkStatus(std::map<uint256, CForkStatus>& mapForkStatus) = 0;
@@ -100,6 +128,15 @@ public:
     virtual bool GetBlockLocator(const uint256& hashFork, CBlockLocator& locator, uint256& hashDepth, int nIncStep) = 0;
     virtual bool GetBlockInv(const uint256& hashFork, const CBlockLocator& locator, std::vector<uint256>& vBlockHash, std::size_t nMaxCount) = 0;
     virtual bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) = 0;
+
+    /////////////    CheckPoints    /////////////////////
+    virtual bool HasCheckPoints() const = 0;
+    virtual bool GetCheckPointByHeight(int nHeight, CCheckPoint& point) = 0;
+    virtual std::vector<CCheckPoint> CheckPoints() const = 0;
+    virtual CCheckPoint LatestCheckPoint() const = 0;
+    virtual bool VerifyCheckPoint(int nHeight, const uint256& nBlockHash) = 0;
+    virtual bool FindPreviousCheckPointBlock(CBlock& block) = 0;
+
     virtual bool ListForkUnspentBatch(const uint256& hashFork, uint32 nMax, std::map<CDestination, std::vector<CTxUnspent>>& mapUnspent) = 0;
     virtual bool GetVotes(const CDestination& destDelegate, int64& nVotes) = 0;
     virtual bool ListDelegate(uint32 nCount, std::multimap<int64, CDestination>& mapVotes) = 0;

--- a/src/bigbang/blockchain.cpp
+++ b/src/bigbang/blockchain.cpp
@@ -1458,7 +1458,8 @@ void CBlockChain::InitCheckPoints()
 
     if (Config()->nMagicNum == MAINNET_MAGICNUM)
     {
-        vecCheckPoints.assign(
+        vecCheckPoints.push_back(CCheckPoint(0, pCoreProtocol->GetGenesisBlockHash()));
+        /*vecCheckPoints.assign(
             { { 0, uint256("00000000b0a9be545f022309e148894d1e1c853ccac3ef04cb6f5e5c70f41a70") },
               { 100, uint256("000000649ec479bb9944fb85905822cb707eb2e5f42a5d58e598603b642e225d") },
               { 1000, uint256("000003e86cc97e8b16aaa92216a66c2797c977a239bbd1a12476bad68580be73") },
@@ -1470,7 +1471,7 @@ void CBlockChain::InitCheckPoints()
               { 31000, uint256("000079188913bbe13cb3ff76df2ba2f9d2180854750ab9a37dc8d197668d2215") },
               { 40000, uint256("00009c40c22952179a522909e8bec05617817952f3b9aebd1d1e096413fead5b") },
               { 50000, uint256("0000c3506e5e7fae59bee39965fb45e284f86c993958e5ce682566810832e7e8") },
-              { 70000, uint256("000111701e15e979b4633e45b762067c6369e6f0ca8284094f6ce476b10f50de") } });
+              { 70000, uint256("000111701e15e979b4633e45b762067c6369e6f0ca8284094f6ce476b10f50de") } });*/
     }
 
     for (const auto& point : vecCheckPoints)

--- a/src/bigbang/blockchain.cpp
+++ b/src/bigbang/blockchain.cpp
@@ -44,6 +44,8 @@ bool CBlockChain::HandleInitialize()
         return false;
     }
 
+    InitCheckPoints();
+
     return true;
 }
 
@@ -80,6 +82,17 @@ bool CBlockChain::HandleInvoke()
         if (!InsertGenesisBlock(block))
         {
             Error("Failed to create genesis block");
+            return false;
+        }
+    }
+
+    // Check local block compared to checkpoint
+    if (Config()->nMagicNum == MAINNET_MAGICNUM)
+    {
+        CBlock block;
+        if (!FindPreviousCheckPointBlock(block))
+        {
+            StdError("BlockChain", "Find CheckPoint Error when the node starting, you should purge data(bigbang -purge) to resync blockchain");
             return false;
         }
     }
@@ -1437,6 +1450,123 @@ bool CBlockChain::VerifyBlockCertTx(const CBlock& block)
             }
         }
     }
+    return true;
+}
+
+void CBlockChain::InitCheckPoints()
+{
+
+    if (Config()->nMagicNum == MAINNET_MAGICNUM)
+    {
+        vecCheckPoints.assign(
+            { { 0, uint256("00000000b0a9be545f022309e148894d1e1c853ccac3ef04cb6f5e5c70f41a70") },
+              { 100, uint256("000000649ec479bb9944fb85905822cb707eb2e5f42a5d58e598603b642e225d") },
+              { 1000, uint256("000003e86cc97e8b16aaa92216a66c2797c977a239bbd1a12476bad68580be73") },
+              { 2000, uint256("000007d07acd442c737152d0cd9d8e99b6f0177781323ccbe20407664e01da8f") },
+              { 5000, uint256("00001388dbb69842b373352462b869126b9fe912b4d86becbb3ad2bf1d897840") },
+              { 10000, uint256("00002710c3f3cd6c931f568169c645e97744943e02b0135aae4fcb3139c0fa6f") },
+              { 16000, uint256("00003e807c1e13c95e8601d7e870a1e13bc708eddad137a49ba6c0628ce901df") },
+              { 23000, uint256("000059d889977b9d0cd3d3fa149aa4c6e9c9da08c05c016cb800d52b2ecb620c") },
+              { 31000, uint256("000079188913bbe13cb3ff76df2ba2f9d2180854750ab9a37dc8d197668d2215") },
+              { 40000, uint256("00009c40c22952179a522909e8bec05617817952f3b9aebd1d1e096413fead5b") },
+              { 50000, uint256("0000c3506e5e7fae59bee39965fb45e284f86c993958e5ce682566810832e7e8") },
+              { 70000, uint256("000111701e15e979b4633e45b762067c6369e6f0ca8284094f6ce476b10f50de") } });
+    }
+
+    for (const auto& point : vecCheckPoints)
+    {
+        mapCheckPoints.insert(std::make_pair(point.nHeight, point));
+    }
+}
+
+bool CBlockChain::HasCheckPoints() const
+{
+    return mapCheckPoints.size() > 0;
+}
+
+bool CBlockChain::GetCheckPointByHeight(int nHeight, CCheckPoint& point)
+{
+    if (mapCheckPoints.count(nHeight) == 0)
+    {
+        return false;
+    }
+    else
+    {
+        point = mapCheckPoints[nHeight];
+        return true;
+    }
+}
+
+std::vector<IBlockChain::CCheckPoint> CBlockChain::CheckPoints() const
+{
+    return vecCheckPoints;
+}
+
+IBlockChain::CCheckPoint CBlockChain::LatestCheckPoint() const
+{
+    if (!HasCheckPoints())
+    {
+        return CCheckPoint();
+    }
+
+    return vecCheckPoints.back();
+}
+
+bool CBlockChain::VerifyCheckPoint(int nHeight, const uint256& nBlockHash)
+{
+    if (!HasCheckPoints())
+    {
+        return true;
+    }
+
+    CCheckPoint point;
+    if (!GetCheckPointByHeight(nHeight, point))
+    {
+        return true;
+    }
+
+    if (nBlockHash != point.nBlockHash)
+    {
+        return false;
+    }
+
+    Log("Verified checkpoint at height %d/block %s", point.nHeight, point.nBlockHash.ToString().c_str());
+
+    return true;
+}
+
+bool CBlockChain::FindPreviousCheckPointBlock(CBlock& block)
+{
+    if (!HasCheckPoints())
+    {
+        return true;
+    }
+
+    const auto& points = CheckPoints();
+    int numCheckpoints = points.size();
+    for (int i = numCheckpoints - 1; i >= 0; i--)
+    {
+        const CCheckPoint& point = points[i];
+
+        uint256 hashBlock;
+        if (!GetBlockHash(pCoreProtocol->GetGenesisBlockHash(), point.nHeight, hashBlock))
+        {
+            StdTrace("BlockChain", "CheckPoint(%d, %s) doest not exists and continuely try to get previous checkpoint",
+                     point.nHeight, point.nBlockHash.ToString().c_str());
+
+            continue;
+        }
+
+        if (hashBlock != point.nBlockHash)
+        {
+            StdError("BlockChain", "CheckPoint(%d, %s)  does not match block hash %s",
+                     point.nHeight, point.nBlockHash.ToString().c_str(), hashBlock.ToString().c_str());
+            return false;
+        }
+
+        return GetBlock(hashBlock, block);
+    }
+
     return true;
 }
 

--- a/src/bigbang/blockchain.h
+++ b/src/bigbang/blockchain.h
@@ -6,10 +6,10 @@
 #define BIGBANG_BLOCKCHAIN_H
 
 #include <map>
+#include <uint256.h>
 
 #include "base.h"
 #include "blockbase.h"
-
 namespace bigbang
 {
 
@@ -63,6 +63,14 @@ public:
     uint32 DPoSTimestamp(const uint256& hashPrev) override;
     Errno VerifyPowBlock(const CBlock& block, bool& fLongChain) override;
 
+    /////////////    CheckPoints    /////////////////////
+    bool HasCheckPoints() const override;
+    bool GetCheckPointByHeight(int nHeight, CCheckPoint& point) override;
+    std::vector<CCheckPoint> CheckPoints() const override;
+    CCheckPoint LatestCheckPoint() const override;
+    bool VerifyCheckPoint(int nHeight, const uint256& nBlockHash) override;
+    bool FindPreviousCheckPointBlock(CBlock& block) override;
+
 protected:
     bool HandleInitialize() override;
     void HandleDeinitialize() override;
@@ -81,6 +89,8 @@ protected:
                       int64& nReward, CDelegateAgreement& agreement, std::size_t& nEnrollTrust, CBlockIndex** ppIndexRef);
     bool VerifyBlockCertTx(const CBlock& block);
 
+    void InitCheckPoints();
+
 protected:
     boost::shared_mutex rwAccess;
     ICoreProtocol* pCoreProtocol;
@@ -88,6 +98,9 @@ protected:
     storage::CBlockBase cntrBlock;
     xengine::CCache<uint256, CDelegateEnrolled> cacheEnrolled;
     xengine::CCache<uint256, CDelegateAgreement> cacheAgreement;
+
+    std::map<int, CCheckPoint> mapCheckPoints;
+    std::vector<CCheckPoint> vecCheckPoints;
 };
 
 } // namespace bigbang

--- a/src/bigbang/netchn.cpp
+++ b/src/bigbang/netchn.cpp
@@ -947,10 +947,19 @@ bool CNetChannel::HandleEvent(network::CEventPeerBlock& eventBlock)
     uint256& hashFork = eventBlock.hashFork;
     CBlock& block = eventBlock.data;
     uint256 hash = block.GetHash();
-
+    uint32 nBlockHeight = block.GetBlockHeight();
     try
     {
         boost::recursive_mutex::scoped_lock scoped_lock(mtxSched);
+
+        if (Config()->nMagicNum == MAINNET_MAGICNUM && block.IsPrimary())
+        {
+            if (!pBlockChain->VerifyCheckPoint((int)nBlockHeight, hash))
+            {
+                StdError("NetChannel", "block at height %d does not match checkpoint hash", (int)nBlockHeight);
+                throw std::runtime_error("block doest not match checkpoint hash");
+            }
+        }
 
         set<uint64> setSchedPeer, setMisbehavePeer;
         CSchedule& sched = GetSchedule(hashFork);

--- a/src/bigbang/netchn.h
+++ b/src/bigbang/netchn.h
@@ -321,6 +321,11 @@ protected:
     void InnerBroadcastBlockInv(const uint256& hashFork, const uint256& hashBlock);
     void InnerSubmitCachePowBlock();
 
+    const CBasicConfig* Config()
+    {
+        return dynamic_cast<const CBasicConfig*>(xengine::IBase::Config());
+    }
+
 protected:
     network::CBbPeerNet* pPeerNet;
     ICoreProtocol* pCoreProtocol;

--- a/tools/checkpoints.py
+++ b/tools/checkpoints.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+# -*- coding: utf-8 -*-
+
+# This tool refer to btcd checkpoint candidate tool
+# https://github.com/bigbangcore/BigBang/issues/343
+
+import json
+import subprocess
+
+# btcd confirmations is 2016, but we could reduce from 2016 to 1000 confirms,
+# cause we cannot compared with BTC' Hash Rate in the main network
+
+
+def Constant_CheckPointConfirmations():
+    return 1000
+
+
+def get_block_hash(height):
+    json_str = str(subprocess.check_output(
+        ['bigbang', 'getblockhash', str(height)]))
+
+    block_hash_list = json.loads(json_str)
+    if len(block_hash_list) > 1:
+        return False, ''
+    else:
+        return True, block_hash_list[0]
+
+
+def get_block(block_hash):
+    json_str = subprocess.check_output(['bigbang', 'getblock', block_hash])
+    return json.loads(json_str)
+
+
+def get_primary_fork_height():
+    return int(subprocess.check_output(['bigbang', 'getforkheight']))
+
+
+def get_block_type(block_dict):
+    return block_dict['type']
+
+
+def get_block_height(block_dict):
+    return block_dict['height']
+
+
+def get_block_timestamp(block_dict):
+    return block_dict['time']
+
+
+def is_primary_block(block_type):
+    if "primary-" in str(block_type):
+        return True
+    else:
+        return False
+
+
+def main():
+
+    # Get (last height - confirms) from best primary chain
+    end_height = get_primary_fork_height() - Constant_CheckPointConfirmations()
+
+    # block at least have 1000 confirms
+    height_list = [i for i in range(end_height)]
+    # gensis block timestamp
+    prev_block_timestamp = 1575043200
+
+    print 'check point candidate list here: '
+
+    for height in height_list:
+
+        is_success, block_hash = get_block_hash(height)
+        if not is_success:
+            continue
+
+        block_dict = get_block(block_hash)
+        block_type = get_block_type(block_dict)
+        if is_primary_block(block_type):
+            block_height = get_block_height(block_dict)
+            if block_height != height or block_height == 0:
+                continue
+            current_block_timestamp = get_block_timestamp(block_dict)
+            if current_block_timestamp > prev_block_timestamp:
+                checkpoint = (block_height, block_hash)
+                print checkpoint
+                prev_block_timestamp = current_block_timestamp
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
将dpos-mainnet分支的检查点代码移置到dpos分支，使用两个分支的代码差异尽量少，而添加的这个检查点，只做了创世块的检查，所以dpos测试没有问题。