### PR TITLE
No need to import address to vote

### DIFF
--- a/script/template/rpc.json
+++ b/script/template/rpc.json
@@ -759,7 +759,8 @@
             },
             {
                 "request": "curl -d '{\"id\":2,\"method\":\"signrawtransactionwithwallet\",\"jsonrpc\":\"2.0\",\"params\":{\"pubkey\":\"8eb642ae260a8319cb79ff4f13ad9ad737b5dc828f39f8e0fc463a519e8646f4\",\"txdata\":\"010000002bec545e00000000d4a8f445791e35471b69254e444a4eac2e2448f57b420a6535f935c300000000017ce5f6359c021294863e5a84ec873b2fdbbe9833b31ec7e0fc91c1ee41eb545e0001b84ac4218ecd8e54173a42ebf93fba72246e007a75b43fa996f717a9fe754dac000e270700000000404b4c00000000000000\"}}' http://127.0.0.1:19902",
-                "response": "{\"id\":2,\"jsonrpc\":\"2.0\",\"result\":{\"hex\":\"010000002bec545e00000000d4a8f445791e35471b69254e444a4eac2e2448f57b420a6535f935c300000000017ce5f6359c021294863e5a84ec873b2fdbbe9833b31ec7e0fc91c1ee41eb545e0001b84ac4218ecd8e54173a42ebf93fba72246e007a75b43fa996f717a9fe754dac000e270700000000404b4c0000000000004041569011a7f6fbcc7854725179529bad72a0185add2288eeb43e6e7c9f174301c8ac34c2725ba9c6037cc41a3d3ae1ee856088ec3adf3d8457bdecba679d760c\",\"completed\":true}}"            }
+                "response": "{\"id\":2,\"jsonrpc\":\"2.0\",\"result\":{\"hex\":\"010000002bec545e00000000d4a8f445791e35471b69254e444a4eac2e2448f57b420a6535f935c300000000017ce5f6359c021294863e5a84ec873b2fdbbe9833b31ec7e0fc91c1ee41eb545e0001b84ac4218ecd8e54173a42ebf93fba72246e007a75b43fa996f717a9fe754dac000e270700000000404b4c0000000000004041569011a7f6fbcc7854725179529bad72a0185add2288eeb43e6e7c9f174301c8ac34c2725ba9c6037cc41a3d3ae1ee856088ec3adf3d8457bdecba679d760c\",\"completed\":true}}"
+            }
         ],
         "error": [
             "{\"code\":-401,\"message\":\"Not a pubkey used to sign\"}",
@@ -792,7 +793,8 @@
             },
             {
                 "request": "curl -d '{\"id\":3,\"method\":\"sendrawtransaction\",\"jsonrpc\":\"2.0\",\"params\":{\"txdata\":\"010000002bec545e00000000d4a8f445791e35471b69254e444a4eac2e2448f57b420a6535f935c300000000017ce5f6359c021294863e5a84ec873b2fdbbe9833b31ec7e0fc91c1ee41eb545e0001b84ac4218ecd8e54173a42ebf93fba72246e007a75b43fa996f717a9fe754dac000e270700000000404b4c0000000000004041569011a7f6fbcc7854725179529bad72a0185add2288eeb43e6e7c9f174301c8ac34c2725ba9c6037cc41a3d3ae1ee856088ec3adf3d8457bdecba679d760c\"}}' http://127.0.0.1:19902",
-                "response": "{\"id\":3,\"jsonrpc\":\"2.0\",\"result\":\"5e54ec2b2bf20773a05dad519160ff27fcd729260d4fbb6f83a0df819ebbe319\"}"            }
+                "response": "{\"id\":3,\"jsonrpc\":\"2.0\",\"result\":\"5e54ec2b2bf20773a05dad519160ff27fcd729260d4fbb6f83a0df819ebbe319\"}"
+            }
         ],
         "error": [
             "{\"code\":-8,\"message\":\"Raw tx decode failed\"}",
@@ -2450,6 +2452,12 @@
                     "desc": "exchange sign s",
                     "required": false,
                     "opt": "ss"
+                },
+                "sendtodata": {
+                    "type": "string",
+                    "desc": "sendto data",
+                    "required": false,
+                    "opt": "td"
                 }
             }
         },

--- a/src/bigbang/base.h
+++ b/src/bigbang/base.h
@@ -262,7 +262,7 @@ public:
     virtual std::size_t GetTxCount() = 0;
     virtual bool ListTx(const uint256& hashFork, const CDestination& dest, int nOffset, int nCount, std::vector<CWalletTx>& vWalletTx) = 0;
     virtual bool GetBalance(const CDestination& dest, const uint256& hashFork, int nForkHeight, CWalletBalance& balance) = 0;
-    virtual bool SignTransaction(const CDestination& destIn, CTransaction& tx, const int32 nForkHeight, bool& fCompleted) = 0;
+    virtual bool SignTransaction(const CDestination& destIn, CTransaction& tx, const vector<uint8>& vchSendToData, const int32 nForkHeight, bool& fCompleted) = 0;
     virtual bool ArrangeInputs(const CDestination& destIn, const uint256& hashFork, int nForkHeight, CTransaction& tx) = 0;
     virtual bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) = 0;
     /* Update */
@@ -353,7 +353,7 @@ public:
     virtual bool Lock(const crypto::CPubKey& pubkey) = 0;
     virtual bool Unlock(const crypto::CPubKey& pubkey, const crypto::CCryptoString& strPassphrase, int64 nTimeout) = 0;
     virtual bool SignSignature(const crypto::CPubKey& pubkey, const uint256& hash, std::vector<unsigned char>& vchSig) = 0;
-    virtual bool SignTransaction(CTransaction& tx, bool& fCompleted) = 0;
+    virtual bool SignTransaction(CTransaction& tx, const vector<uint8>& vchSendToData, bool& fCompleted) = 0;
     virtual bool HaveTemplate(const CTemplateId& tid) = 0;
     virtual void GetTemplateIds(std::set<CTemplateId>& setTid) = 0;
     virtual bool AddTemplate(CTemplatePtr& ptr) = 0;

--- a/src/bigbang/rpcmod.cpp
+++ b/src/bigbang/rpcmod.cpp
@@ -1738,7 +1738,13 @@ CRPCResultPtr CRPCMod::RPCSendFrom(CRPCParamPtr param)
         ds << pService->GetForkHeight(hashFork) << (txNew.nTxFee + txNew.nAmount);
     }
 
-    if (!pService->SignTransaction(txNew, fCompleted))
+    vector<uint8> vchSendToData;
+    if (to.IsTemplate() && spParam->strSendtodata.IsValid())
+    {
+        vchSendToData = ParseHexString(spParam->strSendtodata);
+    }
+
+    if (!pService->SignTransaction(txNew, vchSendToData, fCompleted))
     {
         throw CRPCException(RPC_WALLET_ERROR, "Failed to sign transaction");
     }
@@ -1849,8 +1855,9 @@ CRPCResultPtr CRPCMod::RPCSignTransaction(CRPCParamPtr param)
         throw CRPCException(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }
 
+    vector<uint8> vchSendToData;
     bool fCompleted = false;
-    if (!pService->SignTransaction(rawTx, fCompleted))
+    if (!pService->SignTransaction(rawTx, vchSendToData, fCompleted))
     {
         throw CRPCException(RPC_WALLET_ERROR, "Failed to sign transaction");
     }

--- a/src/bigbang/service.cpp
+++ b/src/bigbang/service.cpp
@@ -498,7 +498,7 @@ bool CService::SignSignature(const crypto::CPubKey& pubkey, const uint256& hash,
     return pWallet->Sign(pubkey, hash, vchSig);
 }
 
-bool CService::SignTransaction(CTransaction& tx, bool& fCompleted)
+bool CService::SignTransaction(CTransaction& tx, const vector<uint8>& vchSendToData, bool& fCompleted)
 {
     uint256 hashFork;
     int nHeight;
@@ -516,7 +516,7 @@ bool CService::SignTransaction(CTransaction& tx, bool& fCompleted)
 
     const CDestination& destIn = vUnspent[0].destTo;
     int32 nForkHeight = GetForkHeight(hashFork);
-    if (!pWallet->SignTransaction(destIn, tx, nForkHeight, fCompleted))
+    if (!pWallet->SignTransaction(destIn, tx, vchSendToData, nForkHeight, fCompleted))
     {
         StdError("CService", "SignTransaction: SignTransaction fail, txid: %s, destIn: %s", tx.GetHash().GetHex().c_str(), destIn.ToString().c_str());
         return false;

--- a/src/bigbang/service.h
+++ b/src/bigbang/service.h
@@ -63,7 +63,7 @@ public:
     bool Lock(const crypto::CPubKey& pubkey) override;
     bool Unlock(const crypto::CPubKey& pubkey, const crypto::CCryptoString& strPassphrase, int64 nTimeout) override;
     bool SignSignature(const crypto::CPubKey& pubkey, const uint256& hash, std::vector<unsigned char>& vchSig) override;
-    bool SignTransaction(CTransaction& tx, bool& fCompleted) override;
+    bool SignTransaction(CTransaction& tx, const vector<uint8>& vchSendToData, bool& fCompleted) override;
     bool HaveTemplate(const CTemplateId& tid) override;
     void GetTemplateIds(std::set<CTemplateId>& setTid) override;
     bool AddTemplate(CTemplatePtr& ptr) override;

--- a/src/bigbang/wallet.cpp
+++ b/src/bigbang/wallet.cpp
@@ -566,7 +566,7 @@ bool CWallet::GetBalance(const CDestination& dest, const uint256& hashFork, int 
     return true;
 }
 
-bool CWallet::SignTransaction(const CDestination& destIn, CTransaction& tx, const int32 nForkHeight, bool& fCompleted)
+bool CWallet::SignTransaction(const CDestination& destIn, CTransaction& tx, const vector<uint8>& vchSendToData, const int32 nForkHeight, bool& fCompleted)
 {
     vector<uint8> vchSig;
     CDestination sendToDelegate;
@@ -575,16 +575,27 @@ bool CWallet::SignTransaction(const CDestination& destIn, CTransaction& tx, cons
     CTemplateId tid;
     if (tx.sendTo.GetTemplateId(tid) && tid.GetType() == TEMPLATE_VOTE)
     {
-        CTemplatePtr tempPtr = GetTemplate(tid);
-        if (tempPtr != nullptr)
+        if (!vchSendToData.empty())
         {
-            boost::dynamic_pointer_cast<CSendToRecordedTemplate>(tempPtr)->GetDelegateOwnerDestination(sendToDelegate, sendToOwner);
+            CTemplatePtr tempPtr = CTemplate::Import(vchSendToData);
+            if (tempPtr != nullptr && tempPtr->GetTemplateId() == tid)
+            {
+                boost::dynamic_pointer_cast<CSendToRecordedTemplate>(tempPtr)->GetDelegateOwnerDestination(sendToDelegate, sendToOwner);
+            }
         }
         if (sendToDelegate.IsNull() || sendToOwner.IsNull())
         {
-            StdError("CWallet", "SignTransaction: sendTo does not load template, sendTo: %s, txid: %s",
-                     CAddress(tx.sendTo).ToString().c_str(), tx.GetHash().GetHex().c_str());
-            return false;
+            CTemplatePtr tempPtr = GetTemplate(tid);
+            if (tempPtr != nullptr)
+            {
+                boost::dynamic_pointer_cast<CSendToRecordedTemplate>(tempPtr)->GetDelegateOwnerDestination(sendToDelegate, sendToOwner);
+            }
+            if (sendToDelegate.IsNull() || sendToOwner.IsNull())
+            {
+                StdError("CWallet", "SignTransaction: sendTo does not load template, sendTo: %s, txid: %s",
+                         CAddress(tx.sendTo).ToString().c_str(), tx.GetHash().GetHex().c_str());
+                return false;
+            }
         }
         fDestInRecorded = true;
     }

--- a/src/bigbang/wallet.h
+++ b/src/bigbang/wallet.h
@@ -178,7 +178,7 @@ public:
     std::size_t GetTxCount() override;
     bool ListTx(const uint256& hashFork, const CDestination& dest, int nOffset, int nCount, std::vector<CWalletTx>& vWalletTx) override;
     bool GetBalance(const CDestination& dest, const uint256& hashFork, int nForkHeight, CWalletBalance& balance) override;
-    bool SignTransaction(const CDestination& destIn, CTransaction& tx, const int32 nForkHeight, bool& fCompleted) override;
+    bool SignTransaction(const CDestination& destIn, CTransaction& tx, const vector<uint8>& vchSendToData, const int32 nForkHeight, bool& fCompleted) override;
     bool ArrangeInputs(const CDestination& destIn, const uint256& hashFork, int nForkHeight, CTransaction& tx) override;
     bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) override;
     /* Update */
@@ -320,7 +320,7 @@ public:
     {
         return false;
     }
-    virtual bool SignTransaction(const CDestination& destIn, CTransaction& tx,
+    virtual bool SignTransaction(const CDestination& destIn, CTransaction& tx, const vector<uint8>& vchSendToData,
                                  const int32 nForkHeight, bool& fCompleted) override
     {
         return false;


### PR DESCRIPTION
不导入VOTE模板地址的投票方法：
1）使用maketemplate产生模板数据；
2）再使用sendfrom带td参数，该参数为VOTE模板地址的数据，sendfrom中的sendto地址必须是td参数的模板地址对应。
3）使用td参数则不需要导入VOTE模板地址，导入VOTE模板地址，也可以投票，则不需要td参数。