### PR TITLE
Optimize getblockdetail and gettransaction

### DIFF
--- a/src/bigbang/base.h
+++ b/src/bigbang/base.h
@@ -112,6 +112,7 @@ public:
     virtual bool GetOrigin(const uint256& hashFork, CBlock& block) = 0;
     virtual bool Exists(const uint256& hashBlock) = 0;
     virtual bool GetTransaction(const uint256& txid, CTransaction& tx) = 0;
+    virtual bool GetTransaction(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight) = 0;
     virtual bool GetTxLocation(const uint256& txid, uint256& hashFork, int& nHeight) = 0;
     virtual bool GetTxUnspent(const uint256& hashFork, const std::vector<CTxIn>& vInput,
                               std::vector<CTxOut>& vOutput)
@@ -171,6 +172,7 @@ public:
     virtual Errno Push(const CTransaction& tx, uint256& hashFork, CDestination& destIn, int64& nValueIn) = 0;
     virtual void Pop(const uint256& txid) = 0;
     virtual bool Get(const uint256& txid, CTransaction& tx) const = 0;
+    virtual bool Get(const uint256& txid, CAssembledTx& tx) const = 0;
     virtual void ListTx(const uint256& hashFork, std::vector<std::pair<uint256, std::size_t>>& vTxPool) = 0;
     virtual void ListTx(const uint256& hashFork, std::vector<uint256>& vTxPool) = 0;
     virtual bool FilterTx(const uint256& hashFork, CTxFilter& filter) = 0;
@@ -331,7 +333,7 @@ public:
     virtual bool GetBlockEx(const uint256& hashBlock, CBlockEx& block, uint256& hashFork, int& nHeight) = 0;
     virtual bool GetLastBlockOfHeight(const uint256& hashFork, const int nHeight, uint256& hashBlock, int64& nTime) = 0;
     virtual void GetTxPool(const uint256& hashFork, std::vector<std::pair<uint256, std::size_t>>& vTxPool) = 0;
-    virtual bool GetTransaction(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight) = 0;
+    virtual bool GetTransaction(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight, uint256& hashBlock, CDestination& destIn) = 0;
     virtual Errno SendTransaction(CTransaction& tx) = 0;
     virtual bool RemovePendingTx(const uint256& txid) = 0;
     virtual bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) = 0;
@@ -376,8 +378,6 @@ public:
     virtual Errno SubmitWork(const std::vector<unsigned char>& vchWorkData, const CTemplateMintPtr& templMint,
                              crypto::CKey& keyMint, uint256& hashBlock)
         = 0;
-    /* Util */
-    virtual bool GetTxSender(const CTransaction& tx, CAddress& sender) = 0;
 };
 
 class IDataStat : public xengine::IIOModule

--- a/src/bigbang/blockchain.cpp
+++ b/src/bigbang/blockchain.cpp
@@ -318,6 +318,11 @@ bool CBlockChain::GetTransaction(const uint256& txid, CTransaction& tx)
     return cntrBlock.RetrieveTx(txid, tx);
 }
 
+bool CBlockChain::GetTransaction(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight)
+{
+    return cntrBlock.RetrieveTx(txid, tx, hashFork, nHeight);
+}
+
 bool CBlockChain::ExistsTx(const uint256& txid)
 {
     return cntrBlock.ExistsTx(txid);

--- a/src/bigbang/blockchain.h
+++ b/src/bigbang/blockchain.h
@@ -35,6 +35,7 @@ public:
     bool GetOrigin(const uint256& hashFork, CBlock& block) override;
     bool Exists(const uint256& hashBlock) override;
     bool GetTransaction(const uint256& txid, CTransaction& tx) override;
+    bool GetTransaction(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight) override;
     bool ExistsTx(const uint256& txid) override;
     bool GetTxLocation(const uint256& txid, uint256& hashFork, int& nHeight) override;
     bool GetTxUnspent(const uint256& hashFork, const std::vector<CTxIn>& vInput,

--- a/src/bigbang/rpcmod.cpp
+++ b/src/bigbang/rpcmod.cpp
@@ -827,10 +827,10 @@ CRPCResultPtr CRPCMod::RPCGetBlockDetail(CRPCParamPtr param)
     uint256 hashBlock;
     hashBlock.SetHex(spParam->strBlock);
 
-    CBlock block;
+    CBlockEx block;
     uint256 fork;
     int height;
-    if (!pService->GetBlock(hashBlock, block, fork, height))
+    if (!pService->GetBlockEx(hashBlock, block, fork, height))
     {
         throw CRPCException(RPC_INVALID_PARAMETER, "Unknown block");
     }
@@ -849,17 +849,11 @@ CRPCResultPtr CRPCMod::RPCGetBlockDetail(CRPCParamPtr param)
     data.strFork = fork.GetHex();
     data.nHeight = height;
     int nDepth = height < 0 ? 0 : pService->GetForkHeight(fork) - height;
-    CAddress fromMint;
-    if (!pService->GetTxSender(block.txMint, fromMint))
-    {
-        throw CRPCException(RPC_INTERNAL_ERROR,
-                            "No information available about the previous one of this block's mint transaction");
-    }
     if (fork != pCoreProtocol->GetGenesisBlockHash())
     {
         nDepth = nDepth * 30;
     }
-    data.txmint = TxToJSON(block.txMint.GetHash(), block.txMint, hashBlock, fork, nDepth, fromMint.ToString());
+    data.txmint = TxToJSON(block.txMint.GetHash(), block.txMint, fork, hashBlock, nDepth, CAddress().ToString());
     if (block.IsProofOfWork())
     {
         CProofOfHashWorkCompact proof;
@@ -870,15 +864,10 @@ CRPCResultPtr CRPCMod::RPCGetBlockDetail(CRPCParamPtr param)
     {
         data.nBits = 0;
     }
-    for (const CTransaction& tx : block.vtx)
+    for (int i = 0; i < block.vtx.size(); i++)
     {
-        CAddress from;
-        if (!pService->GetTxSender(tx, from))
-        {
-            throw CRPCException(RPC_INTERNAL_ERROR,
-                                "No information available about the previous ones of this block's transactions");
-        }
-        data.vecTx.push_back(TxToJSON(tx.GetHash(), tx, fork, hashBlock, nDepth, from.ToString()));
+        const CTransaction& tx = block.vtx[i];
+        data.vecTx.push_back(TxToJSON(tx.GetHash(), tx, fork, hashBlock, nDepth, CAddress(block.vTxContxt[i].destIn).ToString()));
     }
     return MakeCgetblockdetailResultPtr(data);
 }
@@ -931,12 +920,18 @@ CRPCResultPtr CRPCMod::RPCGetTransaction(CRPCParamPtr param)
     auto spParam = CastParamPtr<CGetTransactionParam>(param);
     uint256 txid;
     txid.SetHex(spParam->strTxid);
+    if (txid == 0)
+    {
+        throw CRPCException(RPC_INVALID_PARAMETER, "Invalid txid");
+    }
 
     CTransaction tx;
     uint256 hashFork;
     int nHeight;
+    uint256 hashBlock;
+    CDestination destIn;
 
-    if (!pService->GetTransaction(txid, tx, hashFork, nHeight))
+    if (!pService->GetTransaction(txid, tx, hashFork, nHeight, hashBlock, destIn))
     {
         throw CRPCException(RPC_INVALID_REQUEST, "No information available about transaction");
     }
@@ -951,49 +946,12 @@ CRPCResultPtr CRPCMod::RPCGetTransaction(CRPCParamPtr param)
     }
 
     int nDepth = nHeight < 0 ? 0 : pService->GetForkHeight(hashFork) - nHeight;
-    CAddress from;
-    if (!pService->GetTxSender(tx, from))
-    {
-        throw CRPCException(RPC_INTERNAL_ERROR, "No information available about the previous one of this transaction");
-    }
-
-    uint256 hashBlock;
     if (hashFork != pCoreProtocol->GetGenesisBlockHash())
     {
         nDepth = nDepth * 30;
     }
 
-    if (nHeight != -1)
-    {
-        std::vector<uint256> vHashBlock;
-        if (!pService->GetBlockHash(hashFork, nHeight, vHashBlock))
-        {
-            throw CRPCException(RPC_INTERNAL_ERROR, "No information available about the vector of block hash");
-        }
-
-        for (const auto& hash : vHashBlock)
-        {
-            CBlock block;
-            uint256 tempHashFork;
-            int tempHeight = 0;
-            if (!pService->GetBlock(hash, block, tempHashFork, tempHeight))
-            {
-                throw CRPCException(RPC_INTERNAL_ERROR, "No information available about the block");
-            }
-
-            auto iter = std::find_if(block.vtx.begin(), block.vtx.end(), [&txid](const CTransaction& tx) -> bool {
-                return txid == tx.GetHash();
-            });
-
-            if (iter != block.vtx.end())
-            {
-                hashBlock = hash;
-                break;
-            }
-        }
-    }
-
-    spResult->transaction = TxToJSON(txid, tx, hashFork, hashBlock, nDepth, from.ToString());
+    spResult->transaction = TxToJSON(txid, tx, hashFork, hashBlock, nDepth, CAddress(destIn).ToString());
     return spResult;
 }
 
@@ -2389,7 +2347,7 @@ CRPCResultPtr CRPCMod::RPCSendRawTransaction(rpc::CRPCParamPtr param)
     if (err != OK)
     {
         throw CRPCException(RPC_TRANSACTION_REJECTED, string("Tx rejected : ")
-                                                      + ErrorString(err));
+                                                          + ErrorString(err));
     }
 
     return MakeCSendRawTransactionResultPtr(rawTx.GetHash().GetHex());
@@ -2511,20 +2469,14 @@ CRPCResultPtr CRPCMod::RPCDecodeTransaction(CRPCParamPtr param)
         throw CRPCException(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }
 
-    uint256 hashFork;
-    int nHeight;
+    uint256 hashFork = rawTx.hashAnchor;
+    /*int nHeight;
     if (!pService->GetBlockLocation(rawTx.hashAnchor, hashFork, nHeight))
     {
         throw CRPCException(RPC_INVALID_PARAMETER, "Unknown anchor block");
-    }
+    }*/
 
-    CAddress from;
-    if (!pService->GetTxSender(rawTx, from))
-    {
-        throw CRPCException(RPC_INTERNAL_ERROR,
-                            "No information available about the previous one of this transaction");
-    }
-    return MakeCDecodeTransactionResultPtr(TxToJSON(rawTx.GetHash(), rawTx, hashFork, uint256(), -1, from.ToString()));
+    return MakeCDecodeTransactionResultPtr(TxToJSON(rawTx.GetHash(), rawTx, hashFork, uint256(), -1, string()));
 }
 
 CRPCResultPtr CRPCMod::RPCListUnspent(CRPCParamPtr param)

--- a/src/bigbang/service.h
+++ b/src/bigbang/service.h
@@ -43,7 +43,7 @@ public:
     bool GetBlockEx(const uint256& hashBlock, CBlockEx& block, uint256& hashFork, int& nHeight) override;
     bool GetLastBlockOfHeight(const uint256& hashFork, const int nHeight, uint256& hashBlock, int64& nTime) override;
     void GetTxPool(const uint256& hashFork, std::vector<std::pair<uint256, std::size_t>>& vTxPool) override;
-    bool GetTransaction(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight) override;
+    bool GetTransaction(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight, uint256& hashBlock, CDestination& destIn) override;
     Errno SendTransaction(CTransaction& tx) override;
     bool RemovePendingTx(const uint256& txid) override;
     bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, std::vector<CTxUnspent>& vUnspent) override;
@@ -83,17 +83,12 @@ public:
                  const CTemplateMintPtr& templMint) override;
     Errno SubmitWork(const std::vector<unsigned char>& vchWorkData, const CTemplateMintPtr& templMint,
                      crypto::CKey& keyMint, uint256& hashBlock) override;
-    /* Util */
-    bool GetTxSender(const CTransaction& tx, CAddress& sender) override;
 
 protected:
     bool HandleInitialize() override;
     void HandleDeinitialize() override;
     bool HandleInvoke() override;
     void HandleHalt() override;
-
-private:
-    CAddress GetBackSender(const CTransaction& tx);
 
 protected:
     ICoreProtocol* pCoreProtocol;

--- a/src/bigbang/txpool.cpp
+++ b/src/bigbang/txpool.cpp
@@ -645,6 +645,18 @@ bool CTxPool::Get(const uint256& txid, CTransaction& tx) const
     return false;
 }
 
+bool CTxPool::Get(const uint256& txid, CAssembledTx& tx) const
+{
+    boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
+    map<uint256, CPooledTx>::const_iterator it = mapTx.find(txid);
+    if (it != mapTx.end())
+    {
+        tx = (*it).second;
+        return true;
+    }
+    return false;
+}
+
 void CTxPool::ListTx(const uint256& hashFork, vector<pair<uint256, size_t>>& vTxPool)
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);

--- a/src/bigbang/txpool.h
+++ b/src/bigbang/txpool.h
@@ -274,7 +274,7 @@ public:
       : nHeightInterval(cache.nHeightInterval), mapCache(cache.mapCache) {}
     CTxCache& operator=(const CTxCache& cache)
     {
-        if(this != &cache)
+        if (this != &cache)
         {
             this->nHeightInterval = cache.nHeightInterval;
             this->mapCache = cache.mapCache;
@@ -366,6 +366,7 @@ public:
     Errno Push(const CTransaction& tx, uint256& hashFork, CDestination& destIn, int64& nValueIn) override;
     void Pop(const uint256& txid) override;
     bool Get(const uint256& txid, CTransaction& tx) const override;
+    bool Get(const uint256& txid, CAssembledTx& tx) const override;
     void ListTx(const uint256& hashFork, std::vector<std::pair<uint256, std::size_t>>& vTxPool) override;
     void ListTx(const uint256& hashFork, std::vector<uint256>& vTxPool) override;
     bool FilterTx(const uint256& hashFork, CTxFilter& filter) override;

--- a/src/storage/blockbase.cpp
+++ b/src/storage/blockbase.cpp
@@ -277,7 +277,6 @@ void CBlockView::InsertBlockList(const uint256& hash, const CBlockEx& block, lis
     }
 }
 
-
 //////////////////////////////
 // CForkHeightIndex
 
@@ -758,6 +757,24 @@ bool CBlockBase::RetrieveTx(const uint256& txid, CTransaction& tx)
         StdTrace("BlockBase", "RetrieveTx::Read %s tx failed", txid.ToString().c_str());
         return false;
     }
+    return true;
+}
+
+bool CBlockBase::RetrieveTx(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight)
+{
+    tx.SetNull();
+    CTxIndex txIndex;
+    if (!dbBlock.RetrieveTxIndex(txid, txIndex, hashFork))
+    {
+        StdTrace("BlockBase", "RetrieveTx::RetrieveTxIndex %s tx failed", txid.ToString().c_str());
+        return false;
+    }
+    if (!tsBlock.Read(tx, txIndex.nFile, txIndex.nOffset))
+    {
+        StdTrace("BlockBase", "RetrieveTx::Read %s tx failed", txid.ToString().c_str());
+        return false;
+    }
+    nHeight = txIndex.nBlockHeight;
     return true;
 }
 

--- a/src/storage/blockbase.h
+++ b/src/storage/blockbase.h
@@ -244,6 +244,7 @@ public:
     bool RetrieveAncestry(const uint256& hash, std::vector<std::pair<uint256, uint256>> vAncestry);
     bool RetrieveOrigin(const uint256& hash, CBlock& block);
     bool RetrieveTx(const uint256& txid, CTransaction& tx);
+    bool RetrieveTx(const uint256& txid, CTransaction& tx, uint256& hashFork, int& nHeight);
     bool RetrieveTx(const uint256& hashFork, const uint256& txid, CTransaction& tx);
     bool RetrieveTxLocation(const uint256& txid, uint256& hashFork, int& nHeight);
     bool RetrieveAvailDelegate(const uint256& hash, int height, const std::vector<uint256>& vBlockRange,


### PR DESCRIPTION
解决getblockdetail慢的问题ISSUE#546，同时改进了gettransaction的获取FROM地址的方式，修改了decodetransaction的处理方式，这个RPC是解析TX数据，所以该TX相关的数据可能不在本节点中，所以把相关查询都删除了，这个大家看看有没有问题。