### PR TITLE
Fix getbalance height bug

### DIFF
--- a/src/bigbang/service.cpp
+++ b/src/bigbang/service.cpp
@@ -595,10 +595,16 @@ CTemplatePtr CService::GetTemplate(const CTemplateId& tid)
 
 bool CService::GetBalance(const CDestination& dest, const uint256& hashFork, CWalletBalance& balance)
 {
-    int nForkHeight = GetForkHeight(hashFork);
-    if (nForkHeight <= 0)
+    int nForkHeight = 0;
     {
-        return false;
+        boost::shared_lock<boost::shared_mutex> rlock(rwForkStatus);
+        map<uint256, CForkStatus>::iterator it = mapForkStatus.find(hashFork);
+        if (it == mapForkStatus.end())
+        {
+            StdError("CService", "GetBalance: Find fork fail, fork: %s", hashFork.GetHex().c_str());
+            return false;
+        }
+        nForkHeight = it->second.nLastBlockHeight;
     }
     return pWallet->GetBalance(dest, hashFork, nForkHeight, balance);
 }


### PR DESCRIPTION
SendFrom中调用了GetBalance，在luashell测试中，创世块的奖励地址要转帐给其它地址时，高度值为0（创世块高度为0），则在GetBalance时会失败，导致SenfFrom失败。