### PR TITLE
Mkf pow hash

### DIFF
--- a/src/bigbang/base.h
+++ b/src/bigbang/base.h
@@ -179,7 +179,7 @@ public:
     virtual bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, const std::vector<CTxUnspent>& vUnpsentOnChain, std::vector<CTxUnspent>& vUnspent) = 0;
     virtual bool ListForkUnspentBatch(const uint256& hashFork, uint32 nMax, const std::map<CDestination, std::vector<CTxUnspent>>& mapUnspentOnChain, std::map<CDestination, std::vector<CTxUnspent>>& mapUnspent) = 0;
     virtual bool FilterTx(const uint256& hashFork, CTxFilter& filter) = 0;
-    virtual bool ArrangeBlockTx(const uint256& hashFork, const uint256& hashPrev, int64 nBlockTime, std::size_t nMaxSize,
+    virtual bool ArrangeBlockTx(const uint256& hashFork, const uint256& hashPrev, int64 nBlockTime, /*std::size_t nMaxSize, */
                                 std::vector<CTransaction>& vtx, int64& nTotalTxFee)
         = 0;
     virtual bool FetchInputs(const uint256& hashFork, const CTransaction& tx, std::vector<CTxOut>& vUnspent) = 0;

--- a/src/bigbang/blockmaker.cpp
+++ b/src/bigbang/blockmaker.cpp
@@ -331,9 +331,9 @@ void CBlockMaker::PrepareBlock(CBlock& block, const uint256& hashPrev, const uin
 
 void CBlockMaker::ArrangeBlockTx(CBlock& block, const uint256& hashFork, const CBlockMakerProfile& profile)
 {
-    size_t nMaxTxSize = MAX_BLOCK_SIZE - GetSerializeSize(block) - profile.GetSignatureSize();
+    // size_t nMaxTxSize = MAX_BLOCK_SIZE - GetSerializeSize(block) - profile.GetSignatureSize();
     int64 nTotalTxFee = 0;
-    if (!pTxPool->ArrangeBlockTx(hashFork, block.hashPrev, block.GetBlockTime(), nMaxTxSize, block.vtx, nTotalTxFee))
+    if (!pTxPool->ArrangeBlockTx(hashFork, block.hashPrev, block.GetBlockTime(), /*nMaxTxSize, */ block.vtx, nTotalTxFee))
     {
         Error("ArrangeBlockTx error, block: %s", block.GetHash().ToString().c_str());
     }

--- a/src/bigbang/core.cpp
+++ b/src/bigbang/core.cpp
@@ -366,10 +366,6 @@ Errno CCoreProtocol::VerifyProofOfWork(const CBlock& block, const CBlockIndex* p
     {
         return DEBUG(ERR_BLOCK_PROOF_OF_WORK_INVALID, "algo or bits error, nAlgo: %d, nBits: %d, vchProof size: %ld.", proof.nAlgo, proof.nBits, block.vchProof.size());
     }
-    if (proof.destMint != block.txMint.sendTo)
-    {
-        return DEBUG(ERR_BLOCK_PROOF_OF_WORK_INVALID, "destMint error, destMint: %s.", proof.destMint.ToString().c_str());
-    }
 
     bool fNegative;
     bool fOverflow;

--- a/src/bigbang/service.cpp
+++ b/src/bigbang/service.cpp
@@ -729,7 +729,7 @@ bool CService::GetWork(vector<unsigned char>& vchWorkData, int& nPrevBlockHeight
         // }
         // else
         // {
-        block.nTimeStamp = max((*it).second.nLastBlockTime, GetNetTime());
+        block.nTimeStamp = max((*it).second.nLastBlockTime + 1, GetNetTime());
         //}
     }
 
@@ -755,6 +755,24 @@ bool CService::GetWork(vector<unsigned char>& vchWorkData, int& nPrevBlockHeight
     proof.nNonce = 0;
     proof.Save(block.vchProof);
 
+    // tx mint
+    CTransaction& txMint = block.txMint;
+    txMint.nType = CTransaction::TX_WORK;
+    txMint.nTimeStamp = nPrevTime + 1;
+    //txMint.hashAnchor = block.hashPrev;
+    txMint.sendTo = CDestination(templMint->GetTemplateId());
+    txMint.nAmount = nReward;
+    // size_t nSigSize = templMint->GetTemplateData().size() + 64 + 2;
+    // size_t nMaxTxSize = MAX_BLOCK_SIZE - GetSerializeSize(block) - nSigSize;
+    int64 nTotalTxFee = 0;
+    if (!pTxPool->ArrangeBlockTx(pCoreProtocol->GetGenesisBlockHash(), block.hashPrev, block.nTimeStamp, /*nMaxTxSize, */ block.vtx, nTotalTxFee))
+    {
+        StdError("CService", "GetWork: ArrangeBlockTx fail");
+        return false;
+    }
+    txMint.nAmount += nTotalTxFee;
+    block.hashMerkle = block.CalcMerkleTreeRoot();
+
     block.GetSerializedProofOfWorkData(vchWorkData);
     return true;
 }
@@ -773,7 +791,7 @@ Errno CService::SubmitWork(const vector<unsigned char>& vchWorkData,
     ss.Write((const char*)&vchWorkData[0], vchWorkData.size());
     try
     {
-        ss >> block.nVersion >> block.nType >> block.nTimeStamp >> block.hashPrev >> block.vchProof;
+        ss >> block.nVersion >> block.nType >> block.nTimeStamp >> block.hashPrev >> block.hashMerkle >> block.vchProof;
         proof.Load(block.vchProof);
         if (proof.nAlgo != CM_CRYPTONIGHT)
         {
@@ -794,23 +812,35 @@ Errno CService::SubmitWork(const vector<unsigned char>& vchWorkData,
         return FAILED;
     }
 
+    CBlock blockPrev;
+    if (!pBlockChain->GetBlock(block.hashPrev, blockPrev))
+    {
+        StdError("CService", "SubmitWork: Get prev block fail");
+        return FAILED;
+    }
+
     CTransaction& txMint = block.txMint;
     txMint.nType = CTransaction::TX_WORK;
-    txMint.nTimeStamp = block.nTimeStamp;
+    txMint.nTimeStamp = blockPrev.nTimeStamp + 1;
     //txMint.hashAnchor = block.hashPrev;
     txMint.sendTo = CDestination(templMint->GetTemplateId());
     txMint.nAmount = nReward;
 
-    size_t nSigSize = templMint->GetTemplateData().size() + 64 + 2;
-    size_t nMaxTxSize = MAX_BLOCK_SIZE - GetSerializeSize(block) - nSigSize;
+    // size_t nSigSize = templMint->GetTemplateData().size() + 64 + 2;
+    // size_t nMaxTxSize = MAX_BLOCK_SIZE - GetSerializeSize(block) - nSigSize;
     int64 nTotalTxFee = 0;
-    if (!pTxPool->ArrangeBlockTx(pCoreProtocol->GetGenesisBlockHash(), block.hashPrev, block.nTimeStamp, nMaxTxSize, block.vtx, nTotalTxFee))
+    if (!pTxPool->ArrangeBlockTx(pCoreProtocol->GetGenesisBlockHash(), block.hashPrev, block.nTimeStamp, /*nMaxTxSize, */ block.vtx, nTotalTxFee))
     {
         StdError("CService", "SubmitWork: ArrangeBlockTx fail");
         return FAILED;
     }
-    block.hashMerkle = block.CalcMerkleTreeRoot();
-    block.txMint.nAmount += nTotalTxFee;
+    txMint.nAmount += nTotalTxFee;
+
+    if (block.hashMerkle != block.CalcMerkleTreeRoot())
+    {
+        StdError("CService", "SubmitWork: hashMerkle is not correct");
+        return FAILED;
+    }
 
     hashBlock = block.GetHash();
     vector<unsigned char> vchMintSig;

--- a/src/bigbang/service.cpp
+++ b/src/bigbang/service.cpp
@@ -752,7 +752,6 @@ bool CService::GetWork(vector<unsigned char>& vchWorkData, int& nPrevBlockHeight
     proof.nAgreement = 0;
     proof.nAlgo = nAlgo;
     proof.nBits = nBits;
-    proof.destMint = CDestination(templMint->GetTemplateId());
     proof.nNonce = 0;
     proof.Save(block.vchProof);
 

--- a/src/bigbang/txpool.cpp
+++ b/src/bigbang/txpool.cpp
@@ -781,37 +781,17 @@ bool CTxPool::ArrangeBlockTx(const uint256& hashFork, const uint256& hashPrev, i
     }
     CTxCache& cache = it->second;
 
-    std::vector<CTransaction> vCacheTx;
-    if (!cache.Retrieve(hashPrev, vCacheTx))
+    if (!cache.Retrieve(hashPrev, vtx))
     {
         StdError("CTxPool", "ArrangeBlockTx: find hashPrev in cache failed");
         return false;
     }
 
-    // const CTxPoolView& viewTx = mapPoolView[hashFork];
-    // if (hashPrev == viewTx.hashLastBlock)
-    // {
-    //     ArrangeBlockTx(hashFork, nBlockTime /*viewTx.nLastBlockTime*/, viewTx.hashLastBlock, nMaxSize, vtx, nTotalTxFee, CBlock::GetBlockHeightByHash(viewTx.hashLastBlock) + 1);
-    //     //cache.AddNew(viewTx.hashLastBlock, vtx);
-    //     StdDebug("CTxPool", "ArrangeBlockTx: hashPrev is last block, target height: %d, new vtx size: %ld, old vtx size: %ld, view tx count: %ld",
-    //              CBlock::GetBlockHeightByHash(viewTx.hashLastBlock) + 1, vtx.size(), vCacheTx.size(), viewTx.Count());
-    // }
-    // else
-    // {
     nTotalTxFee = 0;
-    // size_t currentSize = 0;
-    for (const auto& tx : vCacheTx)
+    for (const auto& tx : vtx)
     {
-        // size_t nSerializeSize = xengine::GetSerializeSize(tx);
-        // currentSize += nSerializeSize;
-        // if (currentSize > nMaxSize)
-        // {
-        //     break;
-        // }
         nTotalTxFee += tx.nTxFee;
-        vtx.push_back(tx);
     }
-    // }
     return true;
 }
 

--- a/src/bigbang/txpool.cpp
+++ b/src/bigbang/txpool.cpp
@@ -11,6 +11,8 @@
 using namespace std;
 using namespace xengine;
 
+static const unsigned int MAX_BLOCK_SIZE_EXCEPT_TX = 512;
+static const unsigned int MAX_BLOCK_TX_SIZE = MAX_BLOCK_SIZE - MAX_BLOCK_SIZE_EXCEPT_TX;
 namespace bigbang
 {
 
@@ -766,7 +768,7 @@ bool CTxPool::FilterTx(const uint256& hashFork, CTxFilter& filter)
     return true;
 }
 
-bool CTxPool::ArrangeBlockTx(const uint256& hashFork, const uint256& hashPrev, int64 nBlockTime, size_t nMaxSize,
+bool CTxPool::ArrangeBlockTx(const uint256& hashFork, const uint256& hashPrev, int64 nBlockTime, /*size_t nMaxSize, */
                              vector<CTransaction>& vtx, int64& nTotalTxFee)
 {
     boost::shared_lock<boost::shared_mutex> rlock(rwAccess);
@@ -786,31 +788,30 @@ bool CTxPool::ArrangeBlockTx(const uint256& hashFork, const uint256& hashPrev, i
         return false;
     }
 
-    const CTxPoolView& viewTx = mapPoolView[hashFork];
-    if (hashPrev == viewTx.hashLastBlock)
+    // const CTxPoolView& viewTx = mapPoolView[hashFork];
+    // if (hashPrev == viewTx.hashLastBlock)
+    // {
+    //     ArrangeBlockTx(hashFork, nBlockTime /*viewTx.nLastBlockTime*/, viewTx.hashLastBlock, nMaxSize, vtx, nTotalTxFee, CBlock::GetBlockHeightByHash(viewTx.hashLastBlock) + 1);
+    //     //cache.AddNew(viewTx.hashLastBlock, vtx);
+    //     StdDebug("CTxPool", "ArrangeBlockTx: hashPrev is last block, target height: %d, new vtx size: %ld, old vtx size: %ld, view tx count: %ld",
+    //              CBlock::GetBlockHeightByHash(viewTx.hashLastBlock) + 1, vtx.size(), vCacheTx.size(), viewTx.Count());
+    // }
+    // else
+    // {
+    nTotalTxFee = 0;
+    // size_t currentSize = 0;
+    for (const auto& tx : vCacheTx)
     {
-        ArrangeBlockTx(hashFork, nBlockTime /*viewTx.nLastBlockTime*/, viewTx.hashLastBlock, nMaxSize, vtx, nTotalTxFee, CBlock::GetBlockHeightByHash(viewTx.hashLastBlock) + 1);
-        //cache.AddNew(viewTx.hashLastBlock, vtx);
-        StdDebug("CTxPool", "ArrangeBlockTx: hashPrev is last block, target height: %d, new vtx size: %ld, old vtx size: %ld, view tx count: %ld",
-                 CBlock::GetBlockHeightByHash(viewTx.hashLastBlock) + 1, vtx.size(), vCacheTx.size(), viewTx.Count());
+        // size_t nSerializeSize = xengine::GetSerializeSize(tx);
+        // currentSize += nSerializeSize;
+        // if (currentSize > nMaxSize)
+        // {
+        //     break;
+        // }
+        nTotalTxFee += tx.nTxFee;
+        vtx.push_back(tx);
     }
-    else
-    {
-        nTotalTxFee = 0;
-        size_t currentSize = 0;
-        for (const auto& tx : vCacheTx)
-        {
-            size_t nSerializeSize = xengine::GetSerializeSize(tx);
-            currentSize += nSerializeSize;
-            if (currentSize > nMaxSize)
-            {
-                break;
-            }
-
-            nTotalTxFee += tx.nTxFee;
-            vtx.push_back(tx);
-        }
-    }
+    // }
     return true;
 }
 
@@ -1014,7 +1015,7 @@ bool CTxPool::SynchronizeBlockChain(const CBlockChainUpdate& update, CTxSetChang
     std::vector<CTransaction> vtx;
     int64 nTotalFee = 0;
     const CBlockEx& lastBlockEx = update.vBlockAddNew[0];
-    ArrangeBlockTx(update.hashFork, lastBlockEx.GetBlockTime(), lastBlockEx.GetHash(), MAX_BLOCK_SIZE, vtx, nTotalFee, lastBlockEx.GetBlockHeight() + 1);
+    ArrangeBlockTx(update.hashFork, lastBlockEx.GetBlockTime(), lastBlockEx.GetHash(), MAX_BLOCK_TX_SIZE, vtx, nTotalFee, lastBlockEx.GetBlockHeight() + 1);
 
     auto& cache = mapTxCache[update.hashFork];
     cache.AddNew(lastBlockEx.GetHash(), vtx);

--- a/src/bigbang/txpool.h
+++ b/src/bigbang/txpool.h
@@ -395,7 +395,7 @@ public:
     bool ListForkUnspent(const uint256& hashFork, const CDestination& dest, uint32 nMax, const std::vector<CTxUnspent>& vUnspentOnChain, std::vector<CTxUnspent>& vUnspent) override;
     bool ListForkUnspentBatch(const uint256& hashFork, uint32 nMax, const std::map<CDestination, std::vector<CTxUnspent>>& mapUnspentOnChain, std::map<CDestination, std::vector<CTxUnspent>>& mapUnspent) override;
     bool FilterTx(const uint256& hashFork, CTxFilter& filter) override;
-    bool ArrangeBlockTx(const uint256& hashFork, const uint256& hashPrev, int64 nBlockTime, std::size_t nMaxSize,
+    bool ArrangeBlockTx(const uint256& hashFork, const uint256& hashPrev, int64 nBlockTime, /*std::size_t nMaxSize, */
                         std::vector<CTransaction>& vtx, int64& nTotalTxFee) override;
     bool FetchInputs(const uint256& hashFork, const CTransaction& tx, std::vector<CTxOut>& vUnspent) override;
     bool SynchronizeBlockChain(const CBlockChainUpdate& update, CTxSetChange& change) override;

--- a/src/common/block.h
+++ b/src/common/block.h
@@ -100,7 +100,7 @@ public:
     void GetSerializedProofOfWorkData(std::vector<unsigned char>& vchProofOfWork) const
     {
         xengine::CBufStream ss;
-        ss << nVersion << nType << nTimeStamp << hashPrev << vchProof;
+        ss << nVersion << nType << nTimeStamp << hashPrev << hashMerkle << vchProof;
         vchProofOfWork.assign(ss.GetData(), ss.GetData() + ss.GetSize());
     }
     int64 GetBlockTime() const
@@ -146,10 +146,16 @@ public:
     uint256 BuildMerkleTree(std::vector<uint256>& vMerkleTree) const
     {
         vMerkleTree.clear();
+        vMerkleTree.reserve(vtx.size() + 1);
+
+        vMerkleTree.push_back(txMint.GetHash());
         for (const CTransaction& tx : vtx)
+        {
             vMerkleTree.push_back(tx.GetHash());
+        }
+
         int j = 0;
-        for (int nSize = vtx.size(); nSize > 1; nSize = (nSize + 1) / 2)
+        for (int nSize = vtx.size() + 1; nSize > 1; nSize = (nSize + 1) / 2)
         {
             for (int i = 0; i < nSize; i += 2)
             {

--- a/src/common/proof.h
+++ b/src/common/proof.h
@@ -83,19 +83,18 @@ class CProofOfHashWork : public CProofOfSecretShare
 public:
     unsigned char nAlgo;
     uint32_t nBits;
-    CDestination destMint;
     uint64_t nNonce;
 
 protected:
     virtual void ToStream(xengine::CODataStream& os) override
     {
         CProofOfSecretShare::ToStream(os);
-        os << nAlgo << nBits << destMint.prefix << destMint.data << nNonce;
+        os << nAlgo << nBits << nNonce;
     }
     virtual void FromStream(xengine::CIDataStream& is) override
     {
         CProofOfSecretShare::FromStream(is);
-        is >> nAlgo >> nBits >> destMint.prefix >> destMint.data >> nNonce;
+        is >> nAlgo >> nBits >> nNonce;
     }
 };
 
@@ -104,14 +103,17 @@ class CProofOfHashWorkCompact
 public:
     unsigned char nAlgo;
     uint32_t nBits;
-    CDestination destMint;
     uint64_t nNonce;
 
 public:
     enum
     {
-        PROOFHASHWORK_SIZE = 46
+        PROOFHASHWORK_SIZE = 13
     };
+    CProofOfHashWorkCompact()
+      : nAlgo(0), nBits(0), nNonce(0)
+    {
+    }
     void Save(std::vector<unsigned char>& vchProof)
     {
         if (vchProof.size() < PROOFHASHWORK_SIZE)
@@ -123,9 +125,6 @@ public:
         *p++ = nAlgo;
         *((uint32_t*)p) = nBits;
         p += 4;
-        *p++ = destMint.prefix;
-        *((uint256*)p) = destMint.data;
-        p += 32;
         *((uint64_t*)p) = nNonce;
     }
     void Load(const std::vector<unsigned char>& vchProof)
@@ -139,9 +138,6 @@ public:
         nAlgo = *p++;
         nBits = *((uint32_t*)p);
         p += 4;
-        destMint.prefix = *p++;
-        destMint.data = *((uint256*)p);
-        p += 32;
         nNonce = *((uint64_t*)p);
     }
 };


### PR DESCRIPTION
 - Remove CProofOfHashWorkCompact::destMint
 - First transaction of merkle tree is set to mint tx. Calculate the work of PoW with merkle hash